### PR TITLE
Update for "de" and "hr"

### DIFF
--- a/help/LINGUAS
+++ b/help/LINGUAS
@@ -1,6 +1,7 @@
 ar
 ca
 es
+hr
 pl
 ru
 

--- a/help/hr/hr.po
+++ b/help/hr/hr.po
@@ -1,0 +1,1306 @@
+# Piotr Strebski <strebski@gmail.com>, 2016. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: font-manager help\n"
+"POT-Creation-Date: 2019-04-11 22:52-0400\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2019-07-14 18:49+0200\n"
+"Last-Translator: Milo Ivir <mail@milotype.de>\n"
+"Language-Team: \n"
+"Language: hr\n"
+"X-Generator: Poedit 2.2.3\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+
+#. Put one translator per line, in the form NAME <EMAIL>, YEAR1, YEAR2
+msgctxt "_"
+msgid "translator-credits"
+msgstr "Milo Ivir <mail@milotype.de>, 2019."
+
+#. (itstool) path: info/desc
+#: C/font-manager-categories.page:7
+msgid "Automatically generated categories"
+msgstr "Automatski stvorene kategorije"
+
+#. (itstool) path: page/title
+#: C/font-manager-categories.page:10
+msgid "Categories"
+msgstr "Kategorije"
+
+#. (itstool) path: page/p
+#: C/font-manager-categories.page:12
+msgid ""
+"<app>Font Manager</app> automatically categorizes your fonts based on "
+"various properties."
+msgstr ""
+"<app>Font Manager</app> automatski kategorizira tvoje fontove na osnovi "
+"raznih svojstava."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:19
+msgid "All"
+msgstr "Svi"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:20
+msgid "All available fonts."
+msgstr "Svi dostupni fontovi."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:25
+msgid "System"
+msgstr "Sustav"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:26
+msgid "Fonts available to all users."
+msgstr "Fontovi koji su dostupni svim korisnicima."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:31
+msgid "User"
+msgstr "Korisnik"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:32
+msgid "Fonts available only to you."
+msgstr "Fontovi koji su dostupni samo tebi."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:37
+msgid "Family Kind"
+msgstr "Vrsta obitelji"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:38
+msgid ""
+"Sorted by Family Kind - Requires Panose information to be present in font "
+"metadata."
+msgstr ""
+"Razvrstano po vrsti obitelji – zahtijeva Panose informaciju u meta-podacima "
+"fonta."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:43
+msgid "Width"
+msgstr "Širina"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:44
+msgid "Sorted by font width property."
+msgstr "Razvrstano po širini fonta."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:49
+msgid "Weight"
+msgstr "Debljina"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:50
+msgid "Sorted by font weight property."
+msgstr "Razvrstano po debljini fonta."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:55
+msgid "Slant"
+msgstr "Nagib"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:56
+msgid "Sorted by font slant property."
+msgstr "Razvrstano po nagibu fonta."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:61
+msgid "Spacing"
+msgstr "Metrika"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:62
+msgid "Sorted by font spacing property."
+msgstr "Razvrstano po metrici fonta."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:67
+msgid "License"
+msgstr "Licenca"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:68
+msgid ""
+"Sorted by font license - Requires license information to be present in font "
+"metadata."
+msgstr ""
+"Razvrstano po licenci fontova – zahtijeva informaciju o licenci u meta-"
+"podacima fonta."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:73
+msgid "Vendor"
+msgstr "Proizvođač"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:74
+msgid ""
+"Sorted by font vendor - Requires vendor information to be present in font "
+"metadata."
+msgstr ""
+"Razvrstano po proizvođaču fontova – zahtijeva informaciju o proizvođaču u "
+"meta-podacima fonta."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:79
+msgid "Filetype"
+msgstr "Vrsta datoteke"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:80
+msgid "Sorted by file format."
+msgstr "Razvrstano po datotečnom formatu."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:85
+msgid "Unsorted"
+msgstr "Nerazvrstani"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:86
+msgid "Fonts not present in any of your collections."
+msgstr "Fontovi koji nisu prisutni u nijednoj zbirci."
+
+#. (itstool) path: item/title
+#: C/font-manager-categories.page:91
+msgid "Disabled"
+msgstr "Deaktivirani"
+
+#. (itstool) path: item/p
+#: C/font-manager-categories.page:92
+msgid "Currrently disabled font families."
+msgstr "Trenutačno deaktivirane obitelji fontova."
+
+#. (itstool) path: info/desc
+#: C/font-manager-character-map.page:8
+msgid "View individual characters and their details"
+msgstr "Prikaži pojedinačne znakove i njihove pojedinosti"
+
+#. (itstool) path: page/title
+#: C/font-manager-character-map.page:11
+msgid "Character Map"
+msgstr "Tablica znakova"
+
+#. (itstool) path: page/p
+#: C/font-manager-character-map.page:13
+msgid ""
+"While in \"Manage\" mode the preview pane contains a tab labeled \"Characters"
+"\"."
+msgstr "U prikazu „Upravljaj” postoji kartica s oznakom „Tablica znakova”."
+
+#. (itstool) path: page/p
+#: C/font-manager-character-map.page:17
+msgid ""
+"Selecting this tab allows viewing all glyphs contained in the currently "
+"selected font."
+msgstr ""
+"Odabirom ove kartice omogućuje se prikaz svih znakova trenutačno odabranog "
+"fonta."
+
+#. (itstool) path: figure/title
+#: C/font-manager-character-map.page:23
+msgid "<app>Character Map tab</app>"
+msgstr "<app>Kartica s tablicom znakova</app>"
+
+#. (itstool) path: figure/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/font-manager-character-map.page:24
+msgctxt "_"
+msgid ""
+"external ref='media/character-map.png' md5='a1ada8b4b96568f37c86137fe1fc6565'"
+msgstr ""
+"vanjski ref='media/character-map.png' md5='a1ada8b4b96568f37c86137fe1fc6565'"
+
+#. (itstool) path: note/p
+#: C/font-manager-character-map.page:28
+msgid "Drag characters onto other applications to use them."
+msgstr "Za korištenje slovnih znakova, povuci ih na program."
+
+#. (itstool) path: info/desc
+#: C/font-manager-collections.page:7
+msgid "Organizing Your Fonts"
+msgstr "Organiziranje tvojih fonta"
+
+#. (itstool) path: page/title
+#: C/font-manager-collections.page:10
+msgid "Collections"
+msgstr "Zbirke"
+
+#. (itstool) path: page/p
+#: C/font-manager-collections.page:12
+msgid "<app>Font Manager</app> allows you to define your own collections."
+msgstr "<app>Font Manager</app> ti dozvoljava definirati vlastite zbirke."
+
+#. (itstool) path: page/p
+#: C/font-manager-collections.page:17
+msgid ""
+"Collections allow you to organize your fonts in a way that makes sense to "
+"you and also make it easier to enable or disable many families at once."
+msgstr ""
+"Zbirke omogućuju organiziranje tvojih fontova na način koji ti odgovara i "
+"olakšavaju istovremeno aktiviranje ili deaktiviranje obitelji fontova."
+
+#. (itstool) path: note/p
+#: C/font-manager-collections.page:24
+msgid "Collections do not modify your files in any way."
+msgstr "Zbirke ne mijenjaju tvoje datoteke na nikoji način."
+
+#. (itstool) path: note/p
+#: C/font-manager-collections.page:27
+msgid "Feel free to create or delete as many as you like."
+msgstr "Slobodno stvori ili izbriši koliko god želiš."
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:34
+msgid "Select the Collection view at the bottom of the sidebar."
+msgstr "Odaberi prikaz za zbirke na dnu bočne trake."
+
+#. (itstool) path: item/title
+#: C/font-manager-collections.page:39
+msgid "To create a new collection:"
+msgstr "Za stvaranje nove zbirke:"
+
+#. (itstool) path: gui/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/font-manager-collections.page:45 C/font-manager-font-installation.page:25
+#: C/font-manager-font-sources.page:46 C/font-manager-substitutions.page:37
+#: C/font-manager-substitutions.page:51
+msgctxt "_"
+msgid ""
+"external ref='media/list-add-symbolic.svg' "
+"md5='6fdfd8f68e525f86d3eb943ee14fed32'"
+msgstr ""
+"vanjski ref='media/list-add-symbolic.svg' "
+"md5='6fdfd8f68e525f86d3eb943ee14fed32'"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:42
+msgid ""
+"Click <gui> <media type=\"image\" src=\"media/list-add-symbolic.svg\"/> </"
+"gui> at the top of the Collection view."
+msgstr ""
+"Klikni <gui> <media type=\"image\" src=\"media/list-add-symbolic.svg\"/> </"
+"gui> na vrhu prikaza zbirki."
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:51
+msgid "Enter a name for your new collection"
+msgstr "Upiši naziv za tvoju novu zbirku"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:56
+msgid "Switch back to Category view."
+msgstr "Prebaci natrag na prikaz kategorija."
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:61
+msgid "Add fonts by dragging them from the font list to your new collection."
+msgstr "Dodaj fontove, povlaćenjem fontova iz popisa na tvoju novu zbirku."
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:65
+msgid ""
+"Note : The sidebar will automatically switch to collections from categories "
+"while dragging fonts."
+msgstr ""
+"Napomena: Bočna traka će se iz kategorija automatski prebaciti na zbirke dok "
+"povlačiš fontove."
+
+#. (itstool) path: item/title
+#: C/font-manager-collections.page:73
+msgid "To delete a collection:"
+msgstr "Za brisanje zbirke:"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:76 C/font-manager-collections.page:95
+#: C/font-manager-collections.page:113 C/font-manager-collections.page:131
+msgid "Select the collection"
+msgstr "Odaberi zbirku"
+
+#. (itstool) path: gui/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/font-manager-collections.page:84 C/font-manager-collections.page:144
+#: C/font-manager-font-removal.page:38 C/font-manager-font-sources.page:84
+#: C/font-manager-substitutions.page:99
+msgctxt "_"
+msgid ""
+"external ref='media/list-remove-symbolic.svg' "
+"md5='19b0f1ea55aaa9af1cc99e749fef2a25'"
+msgstr ""
+"vanjski ref='media/list-remove-symbolic.svg' "
+"md5='19b0f1ea55aaa9af1cc99e749fef2a25'"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:81
+msgid ""
+"Click <gui> <media type=\"image\" src=\"media/list-remove-symbolic.svg\"/> </"
+"gui> at the top of the Collection view."
+msgstr ""
+"Klikni <gui> <media type=\"image\" src=\"media/list-remove-symbolic.svg\"/> "
+"</gui> na vrhu prikaza zbirki."
+
+#. (itstool) path: item/title
+#: C/font-manager-collections.page:92
+msgid "To enable a collection:"
+msgstr "Za aktiviranje zbirke:"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:100 C/font-manager-collections.page:118
+#: C/font-manager-font-activation.page:35
+msgid "Click the <gui style=\"checkbox\"> checkbox </gui>"
+msgstr "Klikni <gui style=\"checkbox\"> označni kvadratić </gui>"
+
+#. (itstool) path: item/title
+#: C/font-manager-collections.page:110
+msgid "To disable a collection:"
+msgstr "Za deaktiviranje zbirke:"
+
+#. (itstool) path: item/title
+#: C/font-manager-collections.page:128
+msgid "To remove families from a collection:"
+msgstr "Za uklanjanje obitelji iz zbirke:"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:136
+msgid "Select the family or families you wish to remove"
+msgstr "Odaberi obitelj ili obitelji, koje želiš ukloniti"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:141
+msgid ""
+"Click the <gui> <media type=\"image\" src=\"media/list-remove-symbolic.svg\"/"
+"> </gui> at the top of the font list."
+msgstr ""
+"Klikni <gui> <media type=\"image\" src=\"media/list-remove-symbolic.svg\"/> "
+"</gui> na vrhu popisa fontova."
+
+#. (itstool) path: item/title
+#: C/font-manager-collections.page:152
+msgid "To rename a collection:"
+msgstr "Za preimenovanje zbirke:"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:155
+msgid "Select a collection, click it again"
+msgstr "Odaberi zbirku, ponovo je klikni"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:160
+msgid "Enter a new name"
+msgstr "Upiši novi naziv"
+
+#. (itstool) path: item/p
+#: C/font-manager-collections.page:165
+msgid "Press <gui style=\"button\">Enter</gui>"
+msgstr "Pritisni <gui style=\"button\">Enter</gui>"
+
+#. (itstool) path: info/desc
+#: C/font-manager-font-activation.page:8
+msgid "Activating and De-activating font families"
+msgstr "Aktiviranje i deaktiviranje cijelih obitelji fontova"
+
+#. (itstool) path: page/title
+#: C/font-manager-font-activation.page:11
+msgid "Activation"
+msgstr "Aktivacija"
+
+#. (itstool) path: page/p
+#: C/font-manager-font-activation.page:13
+msgid ""
+"<app>Font Manager</app> allows you to activate and de-activate font families."
+msgstr ""
+"<app>Font Manager</app> ti dozvoljava aktivirati i deaktivirati obitelji "
+"fontova."
+
+#. (itstool) path: page/p
+#: C/font-manager-font-activation.page:18
+msgid ""
+"If you have a large number of fonts installed, font selection dialogs and "
+"lists in many applications can get very long and become uncomfortable to "
+"use, disabling fonts you do not use very often or do not need at the moment "
+"helps keep these at a reasonable size."
+msgstr ""
+"Ako imaš velik broj instaliranih fontova, dijalozi i popisi za odabiranje "
+"fontova mogu u mnogim programima, postati jako dugački i neugodni za "
+"korištenje. Deaktiviranje fontova koje ne koristiš često ili ih trenutačno "
+"ne trebaš, pomaže održati razumnu dužinu popisa fontova."
+
+#. (itstool) path: item/title
+#: C/font-manager-font-activation.page:27
+msgid "To enable or disable a font family:"
+msgstr "Za aktiviranje ili deaktiviranje obitelji fontova:"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-activation.page:30
+msgid "Select the family you wish to enable/disable in the font list"
+msgstr "Odaberi obitelj koju želiš aktivirati/deaktivirati u popisu"
+
+#. (itstool) path: note/p
+#: C/font-manager-font-activation.page:47
+msgid ""
+"You can also double-click, press <gui style=\"button\">Space</gui> or press "
+"<gui style=\"button\">Enter</gui> to toggle the selected font."
+msgstr ""
+"Odabrani font možeš uključiti/isključiti dvostrukim klikom, pritiskom na "
+"<gui style=\"button\">Razmaknicu</gui> ili pritiskom na <gui style=\"button"
+"\">Enter</gui>."
+
+#. (itstool) path: note/p
+#: C/font-manager-font-activation.page:51
+msgid ""
+"<link xref=\"organize#user-collections\">Collections</link> make it easy to "
+"enable or disable multiple families at once."
+msgstr ""
+"<link xref=\"organize#user-collections\">Zbirke</link> olakšavaju "
+"istovremeno aktiviranje ili deaktiviranje obitelji fontova."
+
+#. (itstool) path: note/p
+#: C/font-manager-font-activation.page:58
+msgid ""
+"While any changes made using <app>Font Manager</app> are applied "
+"immediately, open applications may need to be restarted in order to reflect "
+"those changes."
+msgstr ""
+"Dok se sve promjene izvršene pomoću programa <app>Font Manager</app> "
+"primjenjuju odmah, otvoreni programi se možda moraju ponovo pokrenuti, kako "
+"bi se promjene prikazale."
+
+#. (itstool) path: info/desc
+#: C/font-manager-font-installation.page:7
+msgid "Adding fonts for your use"
+msgstr "Dodavanje fontova za korištenje"
+
+#. (itstool) path: page/title
+#: C/font-manager-font-installation.page:10
+msgid "Installation"
+msgstr "Instaliracija"
+
+#. (itstool) path: page/p
+#: C/font-manager-font-installation.page:12
+msgid ""
+"<app>Font Manager</app> supports the most common <link xref=\"supported-"
+"formats\">font formats</link>."
+msgstr ""
+"<app>Font Manager</app> podržava uobičajene <link xref=\"supported-formats"
+"\">font formate</link>."
+
+#. (itstool) path: item/p
+#: C/font-manager-font-installation.page:19 C/font-manager-font-removal.page:32
+msgid "While in <gui style=\"button\">Manage</gui> mode"
+msgstr "U prikazu <gui style=\"button\">Upravljaj</gui>"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-installation.page:22
+msgid ""
+"Click <gui style=\"button\"> <media type=\"image\" src=\"media/list-add-"
+"symbolic.svg\"/> </gui> at the top of the window"
+msgstr ""
+"Klikni <gui style=\"button\"> <media type=\"image\" src=\"media/list-add-"
+"symbolic.svg\"/> </gui> na vrhu prozora"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-installation.page:31
+msgid ""
+"Select the files you wish to install from the file selector dialog that is "
+"displayed and click <gui style=\"button\">Open</gui>"
+msgstr ""
+"Odaberi datoteke koje želiš instalirati iz prikazanog odabirača datoteka i "
+"klikni <gui style=\"button\">Otvori</gui>"
+
+#. (itstool) path: note/p
+#: C/font-manager-font-installation.page:40
+msgid ""
+"Drag and drop is also supported. Simply drag files onto the font list to "
+"install them."
+msgstr ""
+"Povuci/Ispusti je također moguće. Za instaliranje fontova, jednostavno "
+"povuci datoteke na popis fontova."
+
+#. (itstool) path: note/p
+#: C/font-manager-font-installation.page:44
+msgid ""
+"You can drag any supported filetype onto the font list. This includes font "
+"files, directories and archives."
+msgstr ""
+"Sve podržane vrste datoteka možeš povući na popis fontova. To uključuje "
+"datoteke, mape i arhive fontova."
+
+#. (itstool) path: note/p
+#: C/font-manager-font-installation.page:51
+msgid ""
+"Install <link action=\"install:file-roller\" href=\"https://wiki.gnome.org/"
+"Apps/FileRoller\">Archive Manager</link>. to enable support for compressed "
+"files."
+msgstr ""
+"Instaliraj <link action=\"install:file-roller\" href=\"https://wiki.gnome."
+"org/Apps/FileRoller\">Upravljač arhivama</link> za aktiviranje podrške za "
+"komprimirane datoteke."
+
+#. (itstool) path: note/p
+#: C/font-manager-font-installation.page:59 C/font-manager-font-removal.page:76
+#: C/font-manager-font-sources.page:138
+msgid ""
+"<app>Font Manager</app> will reload anytime changes require it. This may "
+"take a moment depending on number of changes."
+msgstr ""
+"<app>Font Manager</app> će aktualizirati prikaz, kadgod promjene to "
+"zahtijevaju. Ovo može nešto potrajati, ovisno o količini promjena."
+
+#. (itstool) path: info/desc
+#: C/font-manager-font-removal.page:8
+msgid "Getting rid of unwanted fonts"
+msgstr "Riješi se neželjenih fontova"
+
+#. (itstool) path: page/title
+#: C/font-manager-font-removal.page:11
+msgid "Removal"
+msgstr "Uklanjanje"
+
+#. (itstool) path: note/p
+#: C/font-manager-font-removal.page:14
+msgid ""
+"The only fonts listed in the removal dialog will be those installed in your "
+"default font directory."
+msgstr ""
+"U dijaloškom okviru za uklanjanje će se navesti samo fontovi, koji su "
+"instalirani u tvojoj standardnoj mapi za fontove."
+
+#. (itstool) path: note/p
+#: C/font-manager-font-removal.page:18
+msgid ""
+"Font files installed system wide are typically installed as part of the "
+"operating system, as packages or by the system administrator. <app>Font "
+"Manager</app> does not provide for removal of such files at this time."
+msgstr ""
+"Datoteke s fontovima koje su instalirane širom sustava obično se instaliraju "
+"kao dio operativnog sustava, kao paketi ili od strane administratora "
+"sustava. <app>Font Manager</app> trenutačno ne omogućuje uklanjanje takvih "
+"datoteka."
+
+#. (itstool) path: item/title
+#: C/font-manager-font-removal.page:29
+msgid "To remove fonts you no longer need:"
+msgstr "Za uklanjanje nepotrebnih fontova:"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-removal.page:35
+msgid ""
+"Click <gui style=\"button\"> <media type=\"image\" src=\"media/list-remove-"
+"symbolic.svg\"/> </gui> at the top of the window"
+msgstr ""
+"Klikni <gui style=\"button\"> <media type=\"image\" src=\"media/list-remove-"
+"symbolic.svg\"/> </gui> na vrhu prozora"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-removal.page:44
+msgid ""
+"Select the families or individual styles you wish to remove from the list "
+"that is displayed"
+msgstr ""
+"Odaberi obitelji ili pojedine stilove, koje želiš ukloniti iz prikazanog "
+"popisa"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-removal.page:50
+msgid "Click <gui style=\"button\">Delete</gui>"
+msgstr "Klikni <gui style=\"button\">Izbriši</gui>"
+
+#. (itstool) path: note/p
+#: C/font-manager-font-removal.page:60
+msgid ""
+"<app>Font Manager</app> organizes and stores installed fonts in the default "
+"user font directory."
+msgstr ""
+"<app>Font Manager</app> organizira i sprema instalirane fontove u standardnu "
+"korisničku mapu za fontove."
+
+#. (itstool) path: note/p
+#: C/font-manager-font-removal.page:63
+msgid ""
+"Current default user font directory is located at <code><file>~/.local/share/"
+"fonts</file></code>"
+msgstr ""
+"Trenutačna standardna korisnička mapa za fontove se nalazi u <code><file>~/."
+"local/share/fonts</file></code>"
+
+#. (itstool) path: note/p
+#: C/font-manager-font-removal.page:69
+msgid ""
+"Files are permanently deleted. Before removing any fonts ensure you have "
+"backups if there is a chance you may need them again."
+msgstr ""
+"Datoteke se trajno brišu. Prije uklanjanja bilo kojih fontova, osiguraj da "
+"imaš sigurnosne kopije, ako postoji mogućnost, da će ti možda ponovno "
+"zatrebati."
+
+#. (itstool) path: info/desc
+#: C/font-manager-font-sources.page:7
+msgid "Adding and removing font directories"
+msgstr "Dodavanje ili uklanjanje mape za fontove"
+
+#. (itstool) path: page/title
+#: C/font-manager-font-sources.page:10
+msgid "Sources"
+msgstr "Izvori"
+
+#. (itstool) path: page/p
+#: C/font-manager-font-sources.page:12
+msgid ""
+"<app>Font Manager</app> allows you to add or remove directories to scan for "
+"font files. Added directories are scanned recursively."
+msgstr ""
+"<app>Font Manager</app> ti dozvoljava dodati i ukloniti mape u kojima će se "
+"tražiti datoteke fontova. Dodane mape se pretražuju rekurzivno."
+
+#. (itstool) path: page/p
+#: C/font-manager-font-sources.page:17
+msgid ""
+"This allows keeping font files somewhere other than your home directory or "
+"temporarily \"installing\" a directory of fonts."
+msgstr ""
+"Ovo omogućuje čuvanje datoteka fontova negdje drugdje, nego u tvojoj "
+"početnoj mapi ili privremeno „instaliranje” mape za fontove."
+
+#. (itstool) path: page/p
+#: C/font-manager-font-sources.page:21
+msgid "It also allows you to organize your font files anyway you like."
+msgstr "Dozvoljava i proizvoljno organiziranje font datoteka."
+
+#. (itstool) path: item/title
+#: C/font-manager-font-sources.page:27
+msgid "To add a source:"
+msgstr "Za dodavanje izvora:"
+
+#. (itstool) path: gui/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/font-manager-font-sources.page:34 C/font-manager-font-sources.page:66
+#: C/font-manager-font-sources.page:98 C/font-manager-substitutions.page:25
+#: C/font-manager-substitutions.page:82 C/font-manager-substitutions.page:120
+msgctxt "_"
+msgid ""
+"external ref='media/preferences-system-symbolic.svg' "
+"md5='63ed081f78639fc6ec234a9351cf52e6'"
+msgstr ""
+"vanjski ref='media/preferences-system-symbolic.svg' "
+"md5='63ed081f78639fc6ec234a9351cf52e6'"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:30 C/font-manager-font-sources.page:62
+#: C/font-manager-substitutions.page:21 C/font-manager-substitutions.page:78
+#: C/font-manager-substitutions.page:116
+msgid ""
+"Open the <app>Font Manager</app> preferences dialog by clicking <gui> <media "
+"type=\"image\" src=\"media/preferences-system-symbolic.svg\"/> </gui> at the "
+"top of the window."
+msgstr ""
+"Otvori dijaloški okvir za svojstva programa <app>Font Manager</app> klikom "
+"na <gui> <media type=\"image\" src=\"media/preferences-system-symbolic.svg\"/"
+"> </gui> na vrhu prozora."
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:40 C/font-manager-font-sources.page:72
+#: C/font-manager-font-sources.page:104
+msgid "Select \"Sources\" from the sidebar"
+msgstr "Odaberi „Izvori” iz bočne trake"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:43
+msgid ""
+"Click <gui> <media type=\"image\" src=\"media/list-add-symbolic.svg\"/> </"
+"gui>"
+msgstr ""
+"Klikni <gui> <media type=\"image\" src=\"media/list-add-symbolic.svg\"/> </"
+"gui>"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:51
+msgid ""
+"Select the directory you wish to add from the file selector that is displayed"
+msgstr "Odaberi mapu koju želiš dodati iz prikazanog odabirača datoteka"
+
+#. (itstool) path: item/title
+#: C/font-manager-font-sources.page:59
+msgid "To remove a source:"
+msgstr "Za uklanjanje izvora:"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:75
+msgid "Select the directory you wish to remove from the list that is displayed"
+msgstr "Odaberi mapu koju želiš ukloniti iz prikazanog popisa"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:81
+msgid ""
+"Click <gui> <media type=\"image\" src=\"media/list-remove-symbolic.svg\"/> </"
+"gui>"
+msgstr ""
+"Klikni <gui> <media type=\"image\" src=\"media/list-remove-symbolic.svg\"/> "
+"</gui>"
+
+#. (itstool) path: item/title
+#: C/font-manager-font-sources.page:91
+msgid "To enable or disable a source:"
+msgstr "Za aktiviranje ili deaktiviranje izvora:"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:94
+msgid ""
+"Open the <app>Font Manager</app> preferences dialog by clicking <gui style="
+"\"button\"> <media type=\"image\" src=\"media/preferences-system-symbolic.svg"
+"\"/> </gui> at the top of the window."
+msgstr ""
+"Otvori dijaloški okvir za svojstva programa <app>Font Manager</app> klikom "
+"na <gui style=\"button\"> <media type=\"image\" src=\"media/preferences-"
+"system-symbolic.svg\"/> </gui> na vrhu prozora."
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:107
+msgid "Select the source you want to enable or disable"
+msgstr "Odaberi izvor koji želiš aktivirati/deaktivirati"
+
+#. (itstool) path: item/p
+#: C/font-manager-font-sources.page:112
+msgid "Click the <gui> toggle switch </gui>"
+msgstr "Klikni <gui> prekidač </gui>"
+
+#. (itstool) path: note/p
+#: C/font-manager-font-sources.page:124
+msgid ""
+"While sources are always available within the application they are not "
+"available to other applications until they are enabled."
+msgstr ""
+"Dok su izvori uvijek dostupni unutar programa, oni nisu dostupni drugim "
+"programima, dok nisu aktivirani."
+
+#. (itstool) path: note/p
+#: C/font-manager-font-sources.page:131
+msgid ""
+"You can avoid having multiple copies of the same files by adding directories "
+"from other filesystems."
+msgstr ""
+"Možeš izbjeći višestruke kopije istih datoteka, dodavanjem mape iz drugih "
+"datotečnih sustava."
+
+#. (itstool) path: info/desc
+#: C/font-manager-fontconfig.page:7
+msgid "Generate fontconfig configuration files"
+msgstr "Stvori fontconfig konfiguracijske datoteke"
+
+#. (itstool) path: page/title
+#: C/font-manager-fontconfig.page:10
+msgid "Display and Rendering Preferences"
+msgstr "Postavke za prikaz i iscrtavanje"
+
+#. (itstool) path: page/p
+#: C/font-manager-fontconfig.page:12
+msgid ""
+"The \"Display\" and \"Rendering\" panes in the preferences dialog generate "
+"valid fontconfig configuration files for the exposed properties."
+msgstr ""
+"Ploče „Prikaz” i „Iscrtavanje” u dijaloškom okviru postavaka, generiraju "
+"valjane fontconfig konfiguracijske datoteke za prikazana svojstva."
+
+#. (itstool) path: page/p
+#: C/font-manager-fontconfig.page:17
+msgid ""
+"See <link href=\"https://www.freedesktop.org/software/fontconfig/fontconfig-"
+"user.html\">fonts-conf</link> for more details."
+msgstr ""
+"Pogledaj pojedinosti na <link href=\"https://www.freedesktop.org/software/"
+"fontconfig/fontconfig-user.html\">fonts-conf</link>."
+
+#. (itstool) path: note/p
+#: C/font-manager-fontconfig.page:22
+msgid ""
+"Desktop environments and applications may rely on their own configuration "
+"mechanism."
+msgstr ""
+"Neka radna okruženja i aplikacije rade s vlastitim konfiguracijskim "
+"mehanizmima."
+
+#. (itstool) path: info/desc
+#: C/font-manager-introduction.page:5
+msgid "Introduction to <app>Font Manager</app>."
+msgstr "Uvod u <app>Font Manager</app>."
+
+#. (itstool) path: page/p
+#: C/font-manager-introduction.page:10
+msgid "<app>Font Manager</app> allows you to :"
+msgstr "<app>Font Manager</app> ti dozvoljava:"
+
+#. (itstool) path: page/title
+#: C/font-manager-introduction.page:12
+msgid "Introduction"
+msgstr "Uvod"
+
+#. (itstool) path: item/p
+#: C/font-manager-introduction.page:18
+msgid "Preview font files in various ways"
+msgstr "Pregledaj fontove na razne načine"
+
+#. (itstool) path: item/p
+#: C/font-manager-introduction.page:23
+msgid "View available font metadata"
+msgstr "Prikaži dostupne meta-podatke"
+
+#. (itstool) path: item/p
+#: C/font-manager-introduction.page:28
+msgid "Install or remove fonts for your use"
+msgstr "Instaliraj ili ukloni fontove za korištenje"
+
+#. (itstool) path: item/p
+#: C/font-manager-introduction.page:33
+msgid "Group fonts into \"Collections\""
+msgstr "Grupiraj fontove u „Zbirke”"
+
+#. (itstool) path: item/p
+#: C/font-manager-introduction.page:38
+msgid "Enable or disable individual font families or entire collections"
+msgstr ""
+"Aktiviraj ili deaktiviraj pojedinačne obitelji fontova ili cijele zbirke"
+
+#. (itstool) path: item/p
+#: C/font-manager-introduction.page:43
+msgid "Specify different directories to use for fonts"
+msgstr "Odredi različite kategorije za fontove"
+
+#. (itstool) path: item/p
+#: C/font-manager-introduction.page:48
+msgid "Perform font substitution"
+msgstr "Primijeni zamjena fontova"
+
+#. (itstool) path: figure/title
+#: C/font-manager-introduction.page:55
+msgid "<app>Font Manager</app>"
+msgstr "<app>Font Manager</app>"
+
+#. (itstool) path: figure/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/font-manager-introduction.page:57
+msgctxt "_"
+msgid ""
+"external ref='media/main-window.png' md5='d506a2c07ded6116e4bcfc1bc3c465a6'"
+msgstr ""
+"vanjski ref='media/main-window.png' md5='d506a2c07ded6116e4bcfc1bc3c465a6'"
+
+#. (itstool) path: note/p
+#: C/font-manager-introduction.page:61
+msgid ""
+"For more information about <app>Font Manager</app>, please visit the <link "
+"href=\"http://fontmanager.github.io/\"> Homepage </link>"
+msgstr ""
+"Za daljnje informacijo o <app>Font Manageru</app>, posjeti <link href="
+"\"http://fontmanager.github.io/\"> početnu web stranicu </link>"
+
+#. (itstool) path: note/p
+#: C/font-manager-introduction.page:67
+msgid ""
+"To report a bug or make a suggestion regarding the <app>Font Manager</app> "
+"application or this manual, please use the projects <link href=\"https://"
+"github.com/FontManager/master/issues\"> Issue Tracker </link>"
+msgstr ""
+"Za prijavljivanje grešaka ili za slanje prijedloga za program <app>Font "
+"Manager</app> ili za ovaj priručnik, koristi <link href=\"https://github.com/"
+"FontManager/master/issues\"> sustav za praćenje problema </link>"
+
+#. (itstool) path: info/desc
+#: C/font-manager-license.page:7
+msgid "View license information contained in font files"
+msgstr "Prikaži informacije o licenci, sadržane u font datotekama"
+
+#. (itstool) path: page/title
+#: C/font-manager-license.page:10
+msgid "Licensing"
+msgstr "Licenziranje"
+
+#. (itstool) path: page/p
+#: C/font-manager-license.page:12
+msgid ""
+"While in \"Manage\" mode the preview pane contains a tab labeled \"License\"."
+msgstr "U prikazu „Upravljaj” postoji kartica s oznakom „Licenca”."
+
+#. (itstool) path: page/p
+#: C/font-manager-license.page:16
+msgid ""
+"Selecting this tab allows viewing any licensing information contained in the "
+"currently selected font."
+msgstr ""
+"Odabirom ove kartice omogućuje se prikaz informacija o licenci trenutačno "
+"odabranog fonta."
+
+#. (itstool) path: figure/title
+#: C/font-manager-license.page:22
+msgid "<app>Font License tab</app>"
+msgstr "<app>Kartica s licencom fonta</app>"
+
+#. (itstool) path: figure/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/font-manager-license.page:23
+msgctxt "_"
+msgid "external ref='media/license.png' md5='8024acb1a2fcc1a995d09400c6469a32'"
+msgstr "vanjski ref='media/license.png' md5='8024acb1a2fcc1a995d09400c6469a32'"
+
+#. (itstool) path: note/p
+#: C/font-manager-license.page:27
+msgid "Not all font files contain licensing information."
+msgstr "Neki fontovi ne sadrže informacije o licenci."
+
+#. (itstool) path: info/desc
+#: C/font-manager-metadata.page:7
+msgid "View metadata embedded in your font files"
+msgstr "Prikaži meta-podatke ugrađene u font datotekama"
+
+#. (itstool) path: page/title
+#: C/font-manager-metadata.page:10
+msgid "Metadata"
+msgstr "Meta-podaci"
+
+#. (itstool) path: page/p
+#: C/font-manager-metadata.page:12
+msgid ""
+"While in \"Manage\" mode the preview pane contains a tab labeled \"Properties"
+"\"."
+msgstr "U prikazu „Upravljaj” postoji kartica s oznakom „Svojstva”."
+
+#. (itstool) path: page/p
+#: C/font-manager-metadata.page:16
+msgid ""
+"Selecting this tab allows viewing metadata contained in the currently "
+"selected font."
+msgstr ""
+"Odabirom ove kartice omogućuje se prikaz meta-podataka trenutačno odabranog "
+"fonta."
+
+#. (itstool) path: figure/title
+#: C/font-manager-metadata.page:22
+msgid "<app>Font Properties tab</app>"
+msgstr "<app>Kartica sa svojstvima fonta</app>"
+
+#. (itstool) path: figure/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/font-manager-metadata.page:23
+msgctxt "_"
+msgid ""
+"external ref='media/metadata.png' md5='3de5a0e94b4f9ef74e1de91ef8b92027'"
+msgstr ""
+"vanjski ref='media/metadata.png' md5='3de5a0e94b4f9ef74e1de91ef8b92027'"
+
+#. (itstool) path: note/p
+#: C/font-manager-metadata.page:27
+msgid "Some properties are optional and may not be present in all font files."
+msgstr "Neka su svojstva opcionalna te ih neki fontovi nemaju."
+
+#. (itstool) path: info/desc
+#: C/font-manager-orthographies.page:8
+msgid "View languages supported and their coverage"
+msgstr "Prikaži podržane jezike i njihovu pokrivenost"
+
+#. (itstool) path: page/title
+#: C/font-manager-orthographies.page:11
+msgid "Language Support"
+msgstr "Jezična podrška"
+
+#. (itstool) path: page/p
+#: C/font-manager-orthographies.page:13
+msgid ""
+"While the character map is in use the sidebar will switch to displaying the "
+"orthographies supported by the currently selected font."
+msgstr ""
+"Dok se koristi tablica znakova, bočna traka će se prebaciti na prikaz "
+"pravopisa koje trenutačno odabrani font podržava."
+
+#. (itstool) path: page/p
+#: C/font-manager-orthographies.page:18
+msgid ""
+"Selecting an orthography from the list will filter the character map so that "
+"it only displays relevant characters"
+msgstr ""
+"Odabirom pravopisa s popisa, filtrira tablicu znakova tako da prikazuje samo "
+"relevantne znakove"
+
+#. (itstool) path: figure/title
+#: C/font-manager-orthographies.page:28
+msgid "<app>Supported Orthographies</app>"
+msgstr "<app>Podržani pravopisi</app>"
+
+#. (itstool) path: figure/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/font-manager-orthographies.page:29
+msgctxt "_"
+msgid ""
+"external ref='media/orthographies.png' md5='03e57aabb0162f6db3d40dd0fb1987ee'"
+msgstr ""
+"vanjski ref='media/orthographies.png' md5='03e57aabb0162f6db3d40dd0fb1987ee'"
+
+#. (itstool) path: info/desc
+#: C/font-manager-substitutions.page:7
+msgid "Substitute one font family for another"
+msgstr "Zamijeni jednu obitelj fontova drugom obitelji"
+
+#. (itstool) path: page/title
+#: C/font-manager-substitutions.page:10
+msgid "Substitution"
+msgstr "Zamjena"
+
+#. (itstool) path: page/p
+#: C/font-manager-substitutions.page:12
+msgid ""
+"<app>Font Manager</app> allows you to substitute one font family for another."
+msgstr ""
+"<app>Font Manager</app> ti dozvoljava zamijeniti jednu obitelj fontova "
+"drugom obitelji."
+
+#. (itstool) path: item/title
+#: C/font-manager-substitutions.page:18
+msgid "To add a substitute:"
+msgstr "Za dodavanje zamjene:"
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:31 C/font-manager-substitutions.page:88
+#: C/font-manager-substitutions.page:126
+msgid "Select \"Substitutions\" from the sidebar"
+msgstr "Odaberi „Zamjene” iz bočne trake"
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:34
+msgid ""
+"Click <gui> <media type=\"image\" src=\"media/list-add-symbolic.svg\"/> </"
+"gui> in the substitutions pane."
+msgstr ""
+"Klikni <gui> <media type=\"image\" src=\"media/list-add-symbolic.svg\"/> </"
+"gui> u ploči za zamjenu."
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:43
+msgid "Enter the name of the font family you wish to set up a substitute for."
+msgstr "Upiši naziv obitelji fontova, kojoj želiš odrediti zamjenu."
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:48
+msgid ""
+"Click <gui> <media type=\"image\" src=\"media/list-add-symbolic.svg\"/> </"
+"gui> on the right."
+msgstr ""
+"Klikni <gui> <media type=\"image\" src=\"media/list-add-symbolic.svg\"/> </"
+"gui> na desnoj strani."
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:57
+msgid "Enter the name of the substitute family and select the priority level."
+msgstr "Upiši naziv zamijenjene obitelji i odaberi razinu važnosti."
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:62
+msgid "Repeat steps 3 - 6 as needed."
+msgstr "Ponovi korake 3 do 6 po potrebi."
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:67 C/font-manager-substitutions.page:105
+msgid ""
+"Click <gui style=\"button\">Save</gui> to write the configuration file when "
+"done."
+msgstr ""
+"Klikni <gui style=\"button\">Spremi</gui> za zapisivanje konfiguracijske "
+"datoteke nakon završavanja."
+
+#. (itstool) path: item/title
+#: C/font-manager-substitutions.page:75
+msgid "To remove a substitute:"
+msgstr "Za uklanjanje zamjene:"
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:91
+msgid "Select the entry you wish to remove from the list."
+msgstr "Odaberi unos koji želiš ukloniti s popisa."
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:96
+msgid ""
+"Click <gui> <media type=\"image\" src=\"media/list-remove-symbolic.svg\"/> </"
+"gui> in the substitutions pane."
+msgstr ""
+"Klikni <gui> <media type=\"image\" src=\"media/list-remove-symbolic.svg\"/> "
+"</gui> u ploči za zamjenu."
+
+#. (itstool) path: item/title
+#: C/font-manager-substitutions.page:113
+msgid "To remove all substitutes:"
+msgstr "Za uklanjanje svih zamjena:"
+
+#. (itstool) path: item/p
+#: C/font-manager-substitutions.page:129
+msgid "Click <gui style=\"button\"> Discard </gui> in the substitutions pane."
+msgstr "Klikni <gui style=\"button\"> Odbaci </gui> u ploči za zamjenu."
+
+#. (itstool) path: note/p
+#: C/font-manager-substitutions.page:142
+msgid ""
+"Fonts matching the target family are edited to prepend the list of preferred "
+"families before the matching family, append the acceptable families after "
+"the matching family and append the default families to the end of the family "
+"list."
+msgstr ""
+"Fontovi koji se podudaraju s traženom obitelji se uređuju, kako bi se "
+"popunio popis preferiranih obitelji prije odgovarajuće obitelji, dodale "
+"prihvatljive obitelji nakon poklapajuće obitelji i dodale standardne "
+"obitelji na kraj popisa obitelji."
+
+#. (itstool) path: note/p
+#: C/font-manager-substitutions.page:148
+msgid ""
+"While changes are applied immediately open applications may need to be "
+"restarted."
+msgstr ""
+"Dok se promjene primjenjuju odmah, otvoreni programi se možda moraju ponovo "
+"pokrenuti."
+
+#. (itstool) path: info/desc
+#: C/font-manager-supported-formats.page:5
+msgid "Font formats supported by <app>Font Manager</app>."
+msgstr "Font formati koje <app>Font Manager</app> podržava."
+
+#. (itstool) path: page/title
+#: C/font-manager-supported-formats.page:10
+msgid "Supported File Formats"
+msgstr "Podražani datotečni formati"
+
+#. (itstool) path: item/title
+#: C/font-manager-supported-formats.page:14
+msgid "<link href=\"http://wikipedia.org/wiki/TrueType\"> TrueType </link>"
+msgstr "<link href=\"http://wikipedia.org/wiki/TrueType\"> TrueType </link>"
+
+#. (itstool) path: item/title
+#: C/font-manager-supported-formats.page:21
+msgid "<link href=\"http://wikipedia.org/wiki/OpenType\"> OpenType </link>"
+msgstr "<link href=\"http://wikipedia.org/wiki/OpenType\"> OpenType </link>"
+
+#. (itstool) path: item/title
+#: C/font-manager-supported-formats.page:28
+msgid ""
+"<link href=\"http://wikipedia.org/wiki/Type_1_Font#Type_1\"> PostScript Type "
+"1 </link>"
+msgstr ""
+"<link href=\"http://wikipedia.org/wiki/Type_1_Font#Type_1\"> PostScript Type "
+"1 </link>"
+
+#. (itstool) path: info/desc
+#: C/index.page:6
+msgid "Getting started with Font Manager."
+msgstr "Prvi koraci s programom Font Manager."
+
+#. (itstool) path: title/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/index.page:8
+msgctxt "_"
+msgid ""
+"external ref='media/preferences-desktop-font-16.png' "
+"md5='4903102ad113c096aa95ef8a5ccaf0c2'"
+msgstr ""
+"vanjski ref='media/preferences-desktop-font-16.png' "
+"md5='4903102ad113c096aa95ef8a5ccaf0c2'"
+
+#. (itstool) path: info/title
+#: C/index.page:10
+msgctxt "link"
+msgid "Font Manager"
+msgstr "Font Manager"
+
+#. (itstool) path: info/title
+#: C/index.page:11
+msgctxt "text"
+msgid "Font Manager"
+msgstr "Font Manager"
+
+#. (itstool) path: credit/name
+#: C/index.page:14
+msgid "Jerry Casiano"
+msgstr "Jerry Casiano"
+
+#. (itstool) path: credit/years
+#: C/index.page:16
+msgid "2009-2018"
+msgstr "2009. – 2018."
+
+#. (itstool) path: credit/name
+#: C/index.page:20
+msgid "Zanata"
+msgstr "Zanata"
+
+#. (itstool) path: license/p
+#: C/index.page:24
+msgid "GNU General Public License Version 3"
+msgstr "GNU opća javna licenca, verzija 3"
+
+#. (itstool) path: title/media
+#. This is a reference to an external file such as an image or video. When
+#. the file changes, the md5 hash will change to let you know you need to
+#. update your localized copy. The msgstr is not used at all. Set it to
+#. whatever you like once you have updated your copy of the file.
+#: C/index.page:30
+msgctxt "_"
+msgid ""
+"external ref='media/preferences-desktop-font.png' "
+"md5='f9108efe15fb60827b402b9a3a936589'"
+msgstr ""
+"vanjski ref='media/preferences-desktop-font.png' "
+"md5='f9108efe15fb60827b402b9a3a936589'"
+
+#. (itstool) path: page/title
+#: C/index.page:29
+msgid ""
+"<media type=\"image\" mime=\"image/png\" src=\"media/preferences-desktop-"
+"font.png\"> Font Manager logo </media> Font Manager"
+msgstr ""
+"<media type=\"image\" mime=\"image/png\" src=\"media/preferences-desktop-"
+"font.png\"> Font Manager logo </media> Font Manager"
+
+#. (itstool) path: section/title
+#: C/index.page:37
+msgid "Managing Your Fonts"
+msgstr "Upravljanje tvojim fontovima"
+
+#. (itstool) path: section/title
+#: C/index.page:41
+msgid "Getting to Know Your Fonts"
+msgstr "Upoznaj tvoje fontove"
+
+#. (itstool) path: section/title
+#: C/index.page:45
+msgid "Advanced Features"
+msgstr "Napredne karakteristike"

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,7 +1,7 @@
 am
 ar
 ca
-de_DE
+de
 es
 hr
 pl

--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,1310 @@
+# Font Manager - Simple font management for Gtk+ desktop environments
+#
+# Copyright Â© 2009 - 2016 Jerry Casiano
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author:
+# Jerry Casiano <JerryCasiano@gmail.com>, 2016.
+msgid ""
+msgstr ""
+"Project-Id-Version: font-manager 0.7.5\n"
+"Report-Msgid-Bugs-To: https://github.com/FontManager/master/issues\n"
+"POT-Creation-Date: 2019-04-08 20:13-0400\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2019-07-14 15:42+0200\n"
+"Last-Translator: Milo Ivir <mail@milotype.de>\n"
+"Language-Team: \n"
+"Language: de\n"
+"X-Generator: Poedit 2.2.3\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: data/org.gnome.FontManager.appdata.xml.in.in:9
+#: data/org.gnome.FontManager.desktop.in.in:5
+#: data/org.gnome.FontManager.desktop.in.in:6 lib/vala/About.vala:27
+msgid "Font Manager"
+msgstr "Font Manager"
+
+#: data/org.gnome.FontManager.appdata.xml.in.in:10
+msgid "A simple font management application for Gtk+ Desktop Environments"
+msgstr ""
+"Eine einfache Anwendung zur Verwaltung von Schriftarten für Gtk+ Desktop-"
+"Umgebungen"
+
+#: data/org.gnome.FontManager.appdata.xml.in.in:13
+msgid ""
+"Font Manager is intended to provide a way for average users to easily manage "
+"desktop fonts, without having to resort to command line tools or editing "
+"configuration files by hand."
+msgstr ""
+"Font Manager soll durchschnittlichen Benutzern die einfache Verwaltung von "
+"Desktop-Schriftarten ermöglichen, ohne auf Befehlszeilentools "
+"zurückzugreifen oder Konfigurationsdateien manuell bearbeiten zu müssen."
+
+#: data/org.gnome.FontManager.appdata.xml.in.in:18
+msgid ""
+"While designed primarily with the Gnome Desktop Environment in mind, it "
+"should work well with other Gtk+ desktop environments."
+msgstr ""
+"Obwohl es hauptsächlich für die Gnome-Desktop-Umgebung entwickelt wurde, "
+"sollte es auch mit anderen Gtk+ Desktop-Umgebungen funktionieren."
+
+#: data/org.gnome.FontManager.appdata.xml.in.in:22
+msgid "Font Manager is NOT a professional-grade font management solution."
+msgstr ""
+"Font Manager ist KEINE professionelle Lösung zur Verwaltung von Schriftarten."
+
+#: data/org.gnome.FontManager.desktop.in.in:7
+msgid "Preview, Compare and Manage Fonts"
+msgstr "Vorschau, Vergleich und Verwalten von Schriftarten"
+
+#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
+#: data/org.gnome.FontManager.desktop.in.in:9
+#: data/org.gnome.FontViewer.desktop.in.in:9
+msgid "preferences-desktop-font"
+msgstr "preferences-desktop-font"
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: data/org.gnome.FontManager.desktop.in.in:16
+#: data/org.gnome.FontViewer.desktop.in.in:16
+msgid "Graphics;Viewer;GNOME;GTK;Publishing;"
+msgstr "Grafik;Betrachter;GNOME;GTK;Publizieren;"
+
+#: data/org.gnome.FontViewer.appdata.xml.in.in:9
+#: data/org.gnome.FontViewer.desktop.in.in:5
+#: data/org.gnome.FontViewer.desktop.in.in:6
+#: src/font-viewer/Application.vala:69 src/font-viewer/Application.vala:101
+#: src/font-viewer/MainWindow.vala:25 data/ui/font-viewer-main-window.ui:17
+msgid "Font Viewer"
+msgstr "Schriften-Betrachter"
+
+#: data/org.gnome.FontViewer.appdata.xml.in.in:10
+msgid "A font viewer application for Gtk+ Desktop Environments"
+msgstr ""
+"Eine Anwendung zum Betrachten von Schriftarten in Gtk+ Desktop-Umgebungen"
+
+#: data/org.gnome.FontViewer.appdata.xml.in.in:13
+msgid ""
+"Font Viewer allows previewing font files prior to installation. It features "
+"several ways to preview font files along with a character map and displays "
+"font properties and license details."
+msgstr ""
+"Der Schriften-Betrachter ermöglicht die Vorschau von Schriftdateien noch "
+"bevor sie installiert sind. Dazu gehören mehrere Modi für die Darstellungen, "
+"sowie das Anzeigen der Zeichentabelle, der Schrift-Eigenschaften und der "
+"Lizenzdetails."
+
+#: data/org.gnome.FontViewer.desktop.in.in:7
+msgid "Full featured font file preview application"
+msgstr "Voll funktionsfähige Anwendung zur Vorschau von Schriftdateien"
+
+#: lib/common/font-manager-source.c:224 lib/common/font-manager-source.c:239
+msgid "Source Unavailable"
+msgstr "Quelle nicht verfügbar"
+
+#: lib/unicode/unicode-character-map.c:643
+msgid "Unknown character, unable to identify."
+msgstr "Unbekanntes Zeichen, Identifizierung unmöglich."
+
+#: lib/unicode/unicode-character-map.c:645
+msgid "Not found."
+msgstr "Nicht gefunden."
+
+#: lib/unicode/unicode-character-map.c:647
+msgid "Character found."
+msgstr "Zeichen gefunden."
+
+#: lib/unicode/unicode-info.c:186
+msgid "<Non Private Use High Surrogate>"
+msgstr "<Nicht privater Bereich oberer Ersatzzeichen>"
+
+#: lib/unicode/unicode-info.c:188
+msgid "<Private Use High Surrogate>"
+msgstr "<Privater Bereich oberer Ersatzzeichen>"
+
+#: lib/unicode/unicode-info.c:190
+msgid "<Low Surrogate>"
+msgstr "<Untere Ersatzzeichen>"
+
+#: lib/unicode/unicode-info.c:192
+msgid "<Private Use>"
+msgstr "<Privater Bereich>"
+
+#: lib/unicode/unicode-info.c:194
+msgid "<Plane 15 Private Use>"
+msgstr "<Tafel 15 Privater Bereich>"
+
+#: lib/unicode/unicode-info.c:196
+msgid "<Plane 16 Private Use>"
+msgstr "<Tafel 16 Privater Bereich>"
+
+#: lib/unicode/unicode-info.c:200
+msgid "<not assigned>"
+msgstr "<nicht zugewiesen>"
+
+#: lib/unicode/unicode-info.c:217
+msgid "Other, Control"
+msgstr "Andere, Kontrolzeichen"
+
+#: lib/unicode/unicode-info.c:219
+msgid "Other, Format"
+msgstr "Andere, Format"
+
+#: lib/unicode/unicode-info.c:221
+msgid "Other, Not Assigned"
+msgstr "Andere, nicht zugewiesen"
+
+#: lib/unicode/unicode-info.c:223
+msgid "Other, Private Use"
+msgstr "Andere, private Gebrauch"
+
+#: lib/unicode/unicode-info.c:225
+msgid "Other, Surrogate"
+msgstr "Andere, Ersatzzeichen"
+
+#: lib/unicode/unicode-info.c:227
+msgid "Letter, Lowercase"
+msgstr "Buchstabe, Kleinbuchstabe"
+
+#: lib/unicode/unicode-info.c:229
+msgid "Letter, Modifier"
+msgstr "Buchstabe, Modifikator"
+
+#: lib/unicode/unicode-info.c:231
+msgid "Letter, Other"
+msgstr "Buchstabe, andere"
+
+#: lib/unicode/unicode-info.c:233
+msgid "Letter, Titlecase"
+msgstr "Buchstabe, Überschrift"
+
+#: lib/unicode/unicode-info.c:235
+msgid "Letter, Uppercase"
+msgstr "Buchstabe, Großbuchstabe"
+
+#: lib/unicode/unicode-info.c:237
+msgid "Mark, Spacing Combining"
+msgstr "Marke, zusammenführend mit Dickte"
+
+#: lib/unicode/unicode-info.c:239
+msgid "Mark, Enclosing"
+msgstr "Marke, einschließend"
+
+#: lib/unicode/unicode-info.c:241
+msgid "Mark, Non-Spacing"
+msgstr "Marke, Nicht-Dickte"
+
+#: lib/unicode/unicode-info.c:243
+msgid "Number, Decimal Digit"
+msgstr "Nummer, Dezimalnummer"
+
+#: lib/unicode/unicode-info.c:245
+msgid "Number, Letter"
+msgstr "Nummer, Buchstabe"
+
+#: lib/unicode/unicode-info.c:247
+msgid "Number, Other"
+msgstr "Nummer, andere"
+
+#: lib/unicode/unicode-info.c:249
+msgid "Punctuation, Connector"
+msgstr "Satzzeichen, Verbinder"
+
+#: lib/unicode/unicode-info.c:251
+msgid "Punctuation, Dash"
+msgstr "Satzzeichen, Strich"
+
+#: lib/unicode/unicode-info.c:253
+msgid "Punctuation, Close"
+msgstr "Satzzeichen, schließend"
+
+#: lib/unicode/unicode-info.c:255
+msgid "Punctuation, Final Quote"
+msgstr "Satzzeichen, schließende Anführungszeichen"
+
+#: lib/unicode/unicode-info.c:257
+msgid "Punctuation, Initial Quote"
+msgstr "Satzzeichen, öffnende Anführungszeichen"
+
+#: lib/unicode/unicode-info.c:259
+msgid "Punctuation, Other"
+msgstr "Satzzeichen, andere"
+
+#: lib/unicode/unicode-info.c:261
+msgid "Punctuation, Open"
+msgstr "Satzzeichen, öffnend"
+
+#: lib/unicode/unicode-info.c:263
+msgid "Symbol, Currency"
+msgstr "Symbol, Währungszeichen"
+
+#: lib/unicode/unicode-info.c:265
+msgid "Symbol, Modifier"
+msgstr "Symbol, Modifikator"
+
+#: lib/unicode/unicode-info.c:267
+msgid "Symbol, Math"
+msgstr "Symbol, mathematische Zeichen"
+
+#: lib/unicode/unicode-info.c:269
+msgid "Symbol, Other"
+msgstr "Symbol, andere"
+
+#: lib/unicode/unicode-info.c:271
+msgid "Separator, Line"
+msgstr "Trennzeichen, Linie"
+
+#: lib/unicode/unicode-info.c:273
+msgid "Separator, Paragraph"
+msgstr "Trennzeichen, Absatz"
+
+#: lib/unicode/unicode-info.c:275
+msgid "Separator, Space"
+msgstr "Trennzeichen, Leerzeichen"
+
+#. Unicode assigns "Common" as the script name for any character not
+#. * specifically listed in Scripts.txt
+#: lib/unicode/unicode-info.c:693
+msgid "Common"
+msgstr "Gemeinsame"
+
+#: lib/vala/About.vala:29
+msgid "Simple font management for GTK+ desktop environments"
+msgstr "Einfache Schriftenverwaltung für GTK+ Arbeitsumgebungen"
+
+#: lib/vala/About.vala:35
+msgid ""
+"\n"
+"    This program is free software: you can redistribute it and/or modify\n"
+"    it under the terms of the GNU General Public License as published by\n"
+"    the Free Software Foundation, either version 3 of the License, or\n"
+"    (at your option) any later version.\n"
+"\n"
+"    This program is distributed in the hope that it will be useful,\n"
+"    but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+"    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+"    GNU General Public License for more details.\n"
+"\n"
+"    You should have received a copy of the GNU General Public License\n"
+"    along with this program.\n"
+"\n"
+"    If not, see <http://www.gnu.org/licenses/gpl-3.0.txt>.\n"
+"    "
+msgstr ""
+"\n"
+"     Dieses Programm ist eine freie Software: Du kannst es weitergeben und/"
+"oder\n"
+"     modifizieren unter den Bedingungen der GNU General Public License, so "
+"wie\n"
+"     von der Free Software Foundation veröffentlicht, entweder Version 3 der "
+"Lizenz,\n"
+"     oder (nach Deiner Wahl) eine neuere Version.\n"
+"\n"
+"     Dieses Programm wird verbreitet, in der Hoffnung, dass es nützlich sein "
+"wird,\n"
+"     jedoch OHNE GARANTIE; auch ohne jegliche implizite Garantie von\n"
+"     MARKTGÄNGIGKEIT oder EIGNUNG FÜR EINEN BESTIMMTEN ZWECK. \n"
+"     Siehe GNU General Public License für weitere Details.\n"
+"\n"
+"     Zusammen mit diesem Programm, solltest Du eine Kopie der\n"
+"     GNU General Public License erhalten haben.\n"
+"\n"
+"     Wenn nicht, siehe <http://www.gnu.org/licenses/gpl-3.0.txt>.\n"
+"     "
+
+#: lib/vala/About.vala:66
+msgid "translator-credits"
+msgstr ""
+"Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Milo Ivir <mail@milotype.de>, 2019"
+
+#: lib/vala/FontConfig.vala:38
+msgid "Ultra-Condensed"
+msgstr "Ultraschmal"
+
+#: lib/vala/FontConfig.vala:40
+msgid "Extra-Condensed"
+msgstr "Extraschmal"
+
+#: lib/vala/FontConfig.vala:42
+msgid "Condensed"
+msgstr "Schmal"
+
+#: lib/vala/FontConfig.vala:44
+msgid "Semi-Condensed"
+msgstr "Halbschmal"
+
+#: lib/vala/FontConfig.vala:46
+msgid "Semi-Expanded"
+msgstr "Halbbreit"
+
+#: lib/vala/FontConfig.vala:48
+msgid "Expanded"
+msgstr "Breit"
+
+#: lib/vala/FontConfig.vala:50
+msgid "Extra-Expanded"
+msgstr "Extrabreit"
+
+#: lib/vala/FontConfig.vala:52
+msgid "Ultra-Expanded"
+msgstr "Ultrabreit"
+
+#: lib/vala/FontConfig.vala:69
+msgid "Italic"
+msgstr "Kursiv"
+
+#: lib/vala/FontConfig.vala:71
+msgid "Oblique"
+msgstr "Schräg"
+
+#: lib/vala/FontConfig.vala:124
+msgid "Thin"
+msgstr "Fein"
+
+#: lib/vala/FontConfig.vala:126
+msgid "Ultra-Light"
+msgstr "Ultraleicht"
+
+#: lib/vala/FontConfig.vala:128 lib/vala/FontConfig.vala:208
+msgid "Light"
+msgstr "Leicht"
+
+#: lib/vala/FontConfig.vala:130
+msgid "Book"
+msgstr "Buch"
+
+#: lib/vala/FontConfig.vala:132 lib/vala/FontConfig.vala:186
+msgid "Medium"
+msgstr "Medium"
+
+#: lib/vala/FontConfig.vala:134
+msgid "Semi-Bold"
+msgstr "Halbfett"
+
+#: lib/vala/FontConfig.vala:136
+msgid "Bold"
+msgstr "Fett"
+
+#: lib/vala/FontConfig.vala:138
+msgid "Ultra-Bold"
+msgstr "Ultrafett"
+
+#: lib/vala/FontConfig.vala:140
+msgid "Heavy"
+msgstr "Kräftig"
+
+#: lib/vala/FontConfig.vala:142
+msgid "Ultra-Heavy"
+msgstr "Ultrakräftig"
+
+#: lib/vala/FontConfig.vala:160
+msgid "Proportional"
+msgstr "Proportionale"
+
+#: lib/vala/FontConfig.vala:162
+msgid "Dual Width"
+msgstr "Doppelte Breite"
+
+#: lib/vala/FontConfig.vala:164
+msgid "Monospace"
+msgstr "Dicktengleiche"
+
+#: lib/vala/FontConfig.vala:166
+msgid "Charcell"
+msgstr "Erzwungene Breite"
+
+#: lib/vala/FontConfig.vala:184
+msgid "Slight"
+msgstr "Leicht"
+
+#: lib/vala/FontConfig.vala:188
+msgid "Full"
+msgstr "Voll"
+
+#: lib/vala/FontConfig.vala:190 lib/vala/FontConfig.vala:212
+#: lib/vala/FontConfig.vala:240
+msgid "None"
+msgstr "Ohne"
+
+#: lib/vala/FontConfig.vala:206 data/ui/font-manager-main-window.ui:167
+msgid "Default"
+msgstr "Normal"
+
+#: lib/vala/FontConfig.vala:210
+msgid "Legacy"
+msgstr "Veraltet"
+
+#: lib/vala/FontConfig.vala:230
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#: lib/vala/FontConfig.vala:232
+msgid "RGB"
+msgstr "RGB (Rot-Grün-Blau Teilbildpunktwiedergabe)"
+
+#: lib/vala/FontConfig.vala:234
+msgid "BGR"
+msgstr "BGR (Blau-Grün-Rot Teilbildpunktwiedergabe)"
+
+#: lib/vala/FontConfig.vala:236
+msgid "VRGB"
+msgstr "VRGB (Vertikale Rot-Grün-Blau Teilbildpunktwiedergabe)"
+
+#: lib/vala/FontConfig.vala:238
+msgid "VBGR"
+msgstr "VBGR (Vertikale Blau-Grün-Rot Teilbildpunktwiedergabe)"
+
+#: lib/vala/Metadata.vala:91
+msgid "File does not contain license information."
+msgstr "Datei enthält keine Lizenzinformationen."
+
+#: lib/vala/PreviewPane.vala:120 lib/vala/PreviewPane.vala:229
+#: data/ui/font-manager-main-window.ui:109
+msgid "Preview"
+msgstr "Vorschau"
+
+#: lib/vala/PreviewPane.vala:121 lib/vala/PreviewPane.vala:225
+msgid "Waterfall"
+msgstr "Wasserfall"
+
+#: lib/vala/PreviewPane.vala:122 lib/vala/PreviewPane.vala:227
+msgid "Body Text"
+msgstr "Textbeispiel"
+
+#: src/font-manager/Categories.vala:324
+msgid "All"
+msgstr "Alle"
+
+#: src/font-manager/Categories.vala:324
+msgid "All Fonts"
+msgstr "Alle Schriften"
+
+#: src/font-manager/Categories.vala:326
+msgid "System"
+msgstr "System"
+
+#: src/font-manager/Categories.vala:326
+msgid "Fonts available to all users"
+msgstr "Für alle Benutzer verfügbare Schriften"
+
+#: src/font-manager/Categories.vala:332
+#: data/ui/font-manager-properties-pane.ui:173
+msgid "Width"
+msgstr "Breite"
+
+#: src/font-manager/Categories.vala:332
+msgid "Grouped by font width"
+msgstr "Geordnet nach Schriftbreite"
+
+#: src/font-manager/Categories.vala:334
+#: data/ui/font-manager-properties-pane.ui:209
+msgid "Weight"
+msgstr "Stärke"
+
+#: src/font-manager/Categories.vala:334
+msgid "Grouped by font weight"
+msgstr "Geordnet nach Strichstärke"
+
+#: src/font-manager/Categories.vala:336
+#: data/ui/font-manager-properties-pane.ui:191
+msgid "Slant"
+msgstr "Neigung"
+
+#: src/font-manager/Categories.vala:336
+msgid "Grouped by font angle"
+msgstr "Geordnet nach Schriftwinkel"
+
+#: src/font-manager/Categories.vala:338
+#: data/ui/font-manager-properties-pane.ui:227
+msgid "Spacing"
+msgstr "Dickte"
+
+#: src/font-manager/Categories.vala:338
+msgid "Grouped by font spacing"
+msgstr "Geordnet nach Dicktenart"
+
+#: src/font-manager/Categories.vala:340
+#: data/ui/font-manager-preview-pane.ui:106
+msgid "License"
+msgstr "Lizenz"
+
+#: src/font-manager/Categories.vala:340
+msgid "Grouped by license type"
+msgstr "Geordnet nach Lizenz"
+
+#: src/font-manager/Categories.vala:342
+#: data/ui/font-manager-properties-pane.ui:263
+msgid "Vendor"
+msgstr "Hersteller"
+
+#: src/font-manager/Categories.vala:342
+msgid "Grouped by vendor"
+msgstr "Geordnet nach Hersteller"
+
+#: src/font-manager/Categories.vala:344
+msgid "Filetype"
+msgstr "Dateityp"
+
+#: src/font-manager/Categories.vala:344
+msgid "Grouped by filetype"
+msgstr "Geordnet nach Dateityp"
+
+#: src/font-manager/Categories.vala:360
+msgid "Family Kind"
+msgstr "Familienart"
+
+#: src/font-manager/Categories.vala:360
+msgid "Only fonts which include Panose information will be grouped here."
+msgstr "Nur Schriften mit Panose Informationen werden hier gruppiert."
+
+#: src/font-manager/Categories.vala:361
+msgid "Any"
+msgstr "Alle"
+
+#: src/font-manager/Categories.vala:361
+msgid "No Fit"
+msgstr "Keine Übereinstimmung"
+
+#: src/font-manager/Categories.vala:361
+msgid "Text and Display"
+msgstr "Text und Überschriften"
+
+#: src/font-manager/Categories.vala:361
+msgid "Script"
+msgstr "Schreibschrift"
+
+#: src/font-manager/Categories.vala:361
+msgid "Decorative"
+msgstr "Dekorativ"
+
+#: src/font-manager/Categories.vala:361
+msgid "Pictorial"
+msgstr "Bildhaft"
+
+#: src/font-manager/Categories.vala:385
+msgid "Normal"
+msgstr "Normal"
+
+#: src/font-manager/Categories.vala:390
+msgid "Regular"
+msgstr "Normal"
+
+#: src/font-manager/CellRendererPill.vala:58
+msgid "Variation "
+msgstr "Variation "
+
+#: src/font-manager/CellRendererPill.vala:58
+msgid "Variations"
+msgstr "Variationen"
+
+#: src/font-manager/Collections.vala:23
+msgid "Enter Collection Name"
+msgstr "Namen der Kollektion eintragen"
+
+#: src/font-manager/Collections.vala:118
+msgid "Add new collection"
+msgstr "Neue Kollektion hinzufügen"
+
+#: src/font-manager/Collections.vala:119
+msgid "Remove selected collection"
+msgstr "Ausgewählte Kollektion entfernen"
+
+#: src/font-manager/Collections.vala:365
+msgid "Copying files..."
+msgstr "Kopieren von Dateien …"
+
+#: src/font-manager/Collections.vala:485
+msgid "Copy to..."
+msgstr "Kopieren nach …"
+
+#: src/font-manager/Collections.vala:486
+msgid "Compress..."
+msgstr "Komprimieren …"
+
+#: src/font-manager/Dialogs.vala:47
+msgid "Select Destination"
+msgstr "Ziel auswählen"
+
+#: src/font-manager/Dialogs.vala:50 src/font-manager/Dialogs.vala:70
+#: src/font-manager/Dialogs.vala:98 src/font-manager/Dialogs.vala:129
+#: src/font-manager/Migration.vala:55
+msgid "_Cancel"
+msgstr "_Abbrechen"
+
+#: src/font-manager/Dialogs.vala:52
+msgid "_Select"
+msgstr "Au_swählen"
+
+#: src/font-manager/Dialogs.vala:67
+msgid "Select files to install"
+msgstr "Dateien zum installieren auswählen"
+
+#: src/font-manager/Dialogs.vala:72 src/font-manager/Dialogs.vala:100
+msgid "_Open"
+msgstr "_Öffnen"
+
+#: src/font-manager/Dialogs.vala:95
+msgid "Select source folders"
+msgstr "Quellverzeichnisse auswählen"
+
+#: src/font-manager/Dialogs.vala:130
+msgid "_Delete"
+msgstr "_Entfernen"
+
+#: src/font-manager/Dialogs.vala:135
+msgid "Select fonts to remove"
+msgstr "Schriften zum entfernen auswählen"
+
+#: src/font-manager/Dialogs.vala:147
+msgid "Fonts installed in your home directory will appear here."
+msgstr ""
+"In Deinem Heim-Verzeichnis installierte Schriftarten werden hier angezeigt."
+
+#: src/font-manager/Filters/Collection.vala:49
+msgid "New Collection"
+msgstr "Neue Kollektion"
+
+#: src/font-manager/Filters/Collection.vala:51
+#, c-format
+msgid "Created : %s"
+msgstr "Erstellt : %s"
+
+#: src/font-manager/Filters/Disabled.vala:26
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: src/font-manager/Filters/Disabled.vala:26
+msgid "Fonts which have been disabled"
+msgstr "Deaktivierte Schriften"
+
+#: src/font-manager/Filters/LanguageFilter.vala:28
+msgid "Filter based on language support"
+msgstr "Filter, basierend auf Sprachunterstützung"
+
+#: src/font-manager/Filters/LanguageFilter.vala:48
+msgid "Language"
+msgstr "Sprache"
+
+#: src/font-manager/Filters/Unsorted.vala:26
+msgid "Unsorted"
+msgstr "Unsortiert"
+
+#: src/font-manager/Filters/Unsorted.vala:26
+msgid "Fonts not present in any collection"
+msgstr "Schriften ohne Kollektionszugehörigkeit"
+
+#: src/font-manager/Filters/UserFonts.vala:28
+msgid "User"
+msgstr "Benutzer"
+
+#: src/font-manager/Filters/UserFonts.vala:28
+msgid "Fonts available only to you"
+msgstr "Nur für Dich verfügbare Schriften"
+
+#: src/font-manager/FontList.vala:43
+msgid "Remove selected font from collection"
+msgstr "Ausgewählte Schrift aus Kollektion entfernen"
+
+#: src/font-manager/FontList.vala:48 src/font-manager/FontList.vala:64
+msgid "Expand all"
+msgstr "Alle ausklappen"
+
+#: src/font-manager/FontList.vala:52
+msgid "Search Families..."
+msgstr "Familien durchsuchen …"
+
+#: src/font-manager/FontList.vala:53
+#, c-format
+msgid ""
+"Case insensitive search of family names.\n"
+"\n"
+"Start search using %s to filter based on filepath."
+msgstr ""
+"Suche nach Familiennamen, ohne Berücksichtigung\n"
+"der Groß-/Kleinschreibung.\n"
+"\n"
+"Suche mit „%s“ starten, um nach Dateipfad zu filtern."
+
+#: src/font-manager/FontList.vala:64
+msgid "Collapse all"
+msgstr "Alle einklappen"
+
+#: src/font-manager/FontList.vala:413
+msgid "Install"
+msgstr "Installieren"
+
+#: src/font-manager/FontList.vala:414
+msgid "Copy Location"
+msgstr "Ort der Kopie"
+
+#: src/font-manager/FontList.vala:415
+msgid "Show in Folder"
+msgstr "Im Ordner zeigen"
+
+#: src/font-manager/MainWindow.vala:54 data/ui/font-manager-main-window.ui:154
+msgid "Browse"
+msgstr "Stöbern"
+
+#: src/font-manager/MainWindow.vala:56 data/ui/font-manager-main-window.ui:125
+msgid "Compare"
+msgstr "Vergleichen"
+
+#: src/font-manager/MainWindow.vala:58 data/ui/font-manager-main-window.ui:138
+msgid "Manage"
+msgstr "Verwalten"
+
+#: src/font-manager/Migration.vala:56
+msgid "_Continue"
+msgstr "_Weiter"
+
+#: src/font-manager/Migration.vala:66
+msgid "Update Required"
+msgstr "Aktualisierung wird benötigt"
+
+#: src/font-manager/Migration.vala:209
+msgid ""
+"\n"
+"Font Manager has detected files from a previous installation. Some files "
+"from previous versions are incompatible with this release. Others have been "
+"deprecated or moved.\n"
+"\n"
+"Font Manager will now attempt to migrate your fonts and collections. Files "
+"and settings which are no longer necessary or valid will be deleted. Any "
+"configuration files that could cause a conflict will also be deleted.\n"
+"\n"
+"It is strongly recommended that you back up any important files before "
+"proceeding.\n"
+msgstr ""
+"\n"
+"Font Manager hat Dateien einer früheren Installation gefunden. Einige "
+"Dateien von früheren Versionen sind inkompatibel mit dieser Version, andere "
+"sind veraltet oder wurden verschoben.\n"
+"\n"
+"Font Manager wird nun versuchen Deine Schriften und Kollektionen zu "
+"migrieren. Dateien, welche nicht länger benötig werden oder nicht korrekt "
+"sind, werden entfernt. Alle Einstellungen welche einen Konflikt hervorufen "
+"könnten, werden entfernt.\n"
+"\n"
+"Es wird dringend empfohlen, alle wichtigen Dateien zu sichern bevor Du "
+"weitermachst.\n"
+
+#: src/font-manager/Orthography.vala:228
+msgid "Update in progress"
+msgstr "Aktualisierung läuft"
+
+#: src/font-manager/Orthography.vala:348
+msgid "Coverage"
+msgstr "Anwendungsbereich"
+
+#: src/font-manager/Orthography.vala:380
+msgid "Supported Orthographies"
+msgstr "Unterstützte Rechtschreibungen"
+
+#: src/font-manager/Preferences/Desktop.vala:37
+msgid "Interface Font"
+msgstr "Schrift für Benutzeroberfläche"
+
+#: src/font-manager/Preferences/Desktop.vala:38
+msgid "Font used throughout interface."
+msgstr "Schrift für die Benutzeroberfläche."
+
+#: src/font-manager/Preferences/Desktop.vala:43
+msgid "Document Font"
+msgstr "Schrift für Dokumente"
+
+#: src/font-manager/Preferences/Desktop.vala:44
+msgid "Font used for reading documents."
+msgstr "Schrift zum Lesen von Dokumenten."
+
+#: src/font-manager/Preferences/Desktop.vala:49
+msgid "Monospace Font"
+msgstr "Dicktengleiche Schrift"
+
+#: src/font-manager/Preferences/Desktop.vala:50
+msgid "Monospaced (fixed-width) font for use in locations such as terminals."
+msgstr "Dicktengleiche Schrift (feste Breite) für den Terminal."
+
+#: src/font-manager/Preferences/Desktop.vala:55
+msgid "Text Scaling Factor"
+msgstr "Faktor für Textvergrößerung"
+
+#: src/font-manager/Preferences/Desktop.vala:56
+msgid ""
+"Factor used to enlarge or reduce text display, without changing font size"
+msgstr ""
+"Faktor zum Vergrößern oder Verkleinern der Textanzeige, ohne die "
+"Schriftgröße zu ändern"
+
+#: src/font-manager/Preferences/Desktop.vala:61
+msgid "Antialiasing"
+msgstr "Antialiasing"
+
+#: src/font-manager/Preferences/Desktop.vala:62
+msgid "The type of antialiasing to use when rendering fonts."
+msgstr "Art des Antialiasing zwecks Wiedergabe von Schriften."
+
+#: src/font-manager/Preferences/Desktop.vala:67
+msgid "RGBA order"
+msgstr "RGBA Reihenfloge"
+
+#: src/font-manager/Preferences/Desktop.vala:68
+msgid ""
+"The order of subpixel elements on an LCD screen; only used when antialiasing "
+"is set to rgba."
+msgstr ""
+"Reihenfloge der Teilbildpunkte auf einem LCD Bildschirm; wird nur benutzt, "
+"wenn Antialiasing auf rgba gesetzt ist."
+
+#: src/font-manager/Preferences/Desktop.vala:73
+#: src/font-manager/Preferences/Rendering.vala:81
+msgid "Hinting"
+msgstr "Hinting"
+
+#: src/font-manager/Preferences/Desktop.vala:74
+msgid "The type of hinting to use when rendering fonts."
+msgstr "Art des Hinting zwecks Wiedergabe von Schriften."
+
+#: src/font-manager/Preferences/Desktop.vala:101
+msgid "GNOME desktop settings schema not found"
+msgstr "Schema der GNOME-Desktop-Einstellungen nicht gefunden"
+
+#: src/font-manager/Preferences/Display.vala:37
+#: src/font-manager/Preferences/Rendering.vala:37
+#: src/font-manager/Preferences/Substitutions.vala:63
+msgid "Settings saved to file."
+msgstr "Einstellungen in Datei gespeichert."
+
+#: src/font-manager/Preferences/Display.vala:41
+#: src/font-manager/Preferences/Rendering.vala:41
+#: src/font-manager/Preferences/Substitutions.vala:67
+msgid "Removed configuration file."
+msgstr "Konfigurations-Datei entfern."
+
+#: src/font-manager/Preferences/Display.vala:70
+msgid "Target DPI"
+msgstr "Gewünschte DPI"
+
+#: src/font-manager/Preferences/Display.vala:71
+msgid "Scale Factor"
+msgstr "Vergrößerungs-Faktor"
+
+#: src/font-manager/Preferences/Display.vala:75
+msgid "LCD Filter"
+msgstr "LCD Filter"
+
+#: src/font-manager/Preferences/Preferences.vala:24
+msgid "Interface"
+msgstr "Benutzeroberfläche"
+
+#: src/font-manager/Preferences/Preferences.vala:25
+msgid "Sources"
+msgstr "Quellen"
+
+#: src/font-manager/Preferences/Preferences.vala:26
+msgid "Substitutions"
+msgstr "Ersatz"
+
+#: src/font-manager/Preferences/Preferences.vala:27
+msgid "Desktop"
+msgstr "Schreibtisch"
+
+#: src/font-manager/Preferences/Preferences.vala:28
+msgid "Display"
+msgstr "Anzeige"
+
+#: src/font-manager/Preferences/Preferences.vala:29
+msgid "Rendering"
+msgstr "Wiedergabe"
+
+#: src/font-manager/Preferences/Rendering.vala:80
+msgid "Antialias"
+msgstr "Antialias"
+
+#: src/font-manager/Preferences/Rendering.vala:82
+msgid "Enable Autohinter"
+msgstr "Automatisches Hinting aktivieren"
+
+#: src/font-manager/Preferences/Rendering.vala:91
+msgid "Hinting Style"
+msgstr "Hinting-Stil"
+
+#: src/font-manager/Preferences/Rendering.vala:92
+msgid "Use Embedded Bitmaps"
+msgstr "Eingebaute Bitmaps benutzen"
+
+#: src/font-manager/Preferences/Rendering.vala:94
+#: src/font-manager/Preferences/Rendering.vala:99
+msgid " Size Restrictions "
+msgstr " Größen-Einschränkungen "
+
+#: src/font-manager/Preferences/Rendering.vala:97
+msgid " Apply settings to point sizes "
+msgstr " Einstellungen auf Schriftgröße anwenden "
+
+#: src/font-manager/Preferences/Rendering.vala:157
+msgid "Smaller than"
+msgstr "Kleiner als"
+
+#: src/font-manager/Preferences/Rendering.vala:158
+msgid "Larger than"
+msgstr "Größer als"
+
+#: src/font-manager/Preferences/Sources.vala:35
+msgid "Add source"
+msgstr "Quelle hinzufügen"
+
+#: src/font-manager/Preferences/Sources.vala:37
+msgid "Remove selected source"
+msgstr "Ausgewählte Quelle entfernen"
+
+#: src/font-manager/Preferences/Sources.vala:104
+msgid "Font Sources"
+msgstr "Schrift-Quellen"
+
+#: src/font-manager/Preferences/Sources.vala:105
+msgid "Easily add or preview fonts without actually installing them."
+msgstr ""
+"Füge Schriften hinzu, oder siehe Dir Schriften an, ohne sie zu installieren."
+
+#: src/font-manager/Preferences/Sources.vala:106
+msgid ""
+"To add a new source simply drag a folder onto this area or click the add "
+"button in the toolbar."
+msgstr ""
+"Um eine neue Quelle hinzuzufügen, ziehe einfach einen Ordner in diesen "
+"Bereich oder klicke auf die Schaltfläche zum hinzufügen in der Symbolleiste."
+
+#: src/font-manager/Preferences/Substitutions.vala:33
+msgid "Add alias"
+msgstr "Alias hinzufügen"
+
+#: src/font-manager/Preferences/Substitutions.vala:34
+msgid "Remove selected alias"
+msgstr "Ausgewählten Alias entfernen"
+
+#: src/font-manager/Preferences/Substitutions.vala:224
+msgid "Font Substitutions"
+msgstr "Schrift-Ersetzungen"
+
+#: src/font-manager/Preferences/Substitutions.vala:225
+msgid "Easily substitute one font family for another."
+msgstr "Ersetze einfach eine Schrift-Familie mit einer anderen."
+
+#: src/font-manager/Preferences/Substitutions.vala:226
+msgid "To add a new substitute click the add button in the toolbar."
+msgstr ""
+"Um eine neue Ersetzung hinzuzufügen, klicke auf den Hinzufügen-Knopf in der "
+"Symbolleiste."
+
+#: src/font-manager/Preferences/UserInterface.vala:38
+msgid "Wide Layout"
+msgstr "Breites Layout"
+
+#: src/font-manager/Preferences/UserInterface.vala:41
+msgid "Only When Maximized"
+msgstr "Nur wenn maximiert"
+
+#: src/font-manager/Preferences/UserInterface.vala:44
+msgid "Client Side Decorations"
+msgstr "Optische Funktionen vom Client"
+
+#: src/font-manager/Preferences/UserInterface.vala:46
+msgid "Enable Animations"
+msgstr "Aktiviere Animationen"
+
+#: src/font-manager/Preferences/UserInterface.vala:47
+msgid "Prefer Dark Theme"
+msgstr "Dunklem Thema Vorrang geben"
+
+#: src/font-manager/Preferences/UserInterface.vala:81
+msgid ""
+"CSD enabled. Change will take effect next time the application is started."
+msgstr ""
+"Optische Funktionen vom Client sind aktiviert. Änderungen werden erst nach "
+"Neustart des Programms sichtbar."
+
+#: src/font-manager/Preferences/UserInterface.vala:83
+msgid ""
+"CSD disabled. Change will take effect next time the application is started."
+msgstr ""
+"Optische Funktionen vom Client sind deaktiviert. Änderungen werden erst nach "
+"Neustart des Programms sichtbar."
+
+#: src/font-manager/TitleBar.vala:48
+msgid "Keyboard Shortcuts"
+msgstr "Tastaturkürzel"
+
+#: src/font-manager/TitleBar.vala:49
+#: data/ui/font-manager-shortcuts-window.ui:19
+msgid "Help"
+msgstr "Hilfe"
+
+#: src/font-manager/TitleBar.vala:50
+msgid "About"
+msgstr "Über"
+
+#: src/font-manager/TitleBar.vala:176
+msgid "Add Fonts"
+msgstr "Schriften hinzufügen"
+
+#: src/font-manager/TitleBar.vala:177
+msgid "Remove Fonts"
+msgstr "Schriften entfernen"
+
+#: src/font-manager/TitleBar.vala:185 data/ui/font-manager-main-window.ui:184
+msgid "Preferences"
+msgstr "Einstellungen"
+
+#: src/font-viewer/MainWindow.vala:26
+msgid "Preview font files before installing them."
+msgstr "Siehe Dir Schriften an, noch bevor Du sie installierst."
+
+#: src/font-viewer/MainWindow.vala:27
+msgid "To preview a font simply drag it onto this area."
+msgstr "Für eine Schriften-Vorschau, ziehe die Schrift auf dieses Feld."
+
+#: src/font-viewer/MainWindow.vala:51
+msgid "OpenType Font"
+msgstr "OpenType Schrift"
+
+#: src/font-viewer/MainWindow.vala:52
+msgid "TrueType Font"
+msgstr "TrueType Schrift"
+
+#: src/font-viewer/MainWindow.vala:53
+msgid "PostScript Type 1 Font"
+msgstr "PostScript Type 1 Schrift"
+
+#: src/font-viewer/MainWindow.vala:100 src/font-viewer/MainWindow.vala:231
+msgid "Install Font"
+msgstr "Schriften installieren"
+
+#: src/font-viewer/MainWindow.vala:187
+msgid "No file selected"
+msgstr "Keine ausgewählte Datei"
+
+#: src/font-viewer/MainWindow.vala:188
+msgid "Or unsupported filetype."
+msgstr "Oder nicht unterstützende Dateiarten."
+
+#: src/font-viewer/MainWindow.vala:226
+msgid "Newer version already installed"
+msgstr "Eine neuere Version existiert bereits"
+
+#: src/font-viewer/MainWindow.vala:228
+msgid "Installed"
+msgstr "Installiert"
+
+#: data/ui/font-manager-alias-row.ui:18
+msgid "Enter target family"
+msgstr "Gewünschte Familie eintragen"
+
+#: data/ui/font-manager-alias-row.ui:31
+msgid "Add substitute"
+msgstr "Ersatz hinzufügen"
+
+#: data/ui/font-manager-compare-view.ui:40
+msgid "Add selected font to comparison"
+msgstr "Füge ausgewählte Schrift dem Vergleich hinzu"
+
+#: data/ui/font-manager-compare-view.ui:63
+msgid "Remove selected font from comparison"
+msgstr "Entferne ausgewählte Schrift vom Vergleich"
+
+#: data/ui/font-manager-compare-view.ui:102
+#: data/ui/font-manager-compare-view.ui:104
+msgid "Select background color"
+msgstr "Wähle Hintergrundfarbe"
+
+#: data/ui/font-manager-compare-view.ui:121
+#: data/ui/font-manager-compare-view.ui:123
+msgid "Select text  color"
+msgstr "Wähle Schriftfarbe"
+
+#: data/ui/font-manager-font-config-controls.ui:12
+msgid "Discard"
+msgstr "Verwerfen"
+
+#: data/ui/font-manager-font-config-controls.ui:30
+msgid "Running applications may require a restart to reflect any changes."
+msgstr ""
+"Offene Programme benötigen womöglich einen Neustart um Änderungen sichtbar "
+"zu machen."
+
+#: data/ui/font-manager-font-config-controls.ui:40
+msgid "Save"
+msgstr "Speichern"
+
+#: data/ui/font-manager-language-filter-settings.ui:36
+msgid "Filter Settings"
+msgstr "Filter-Voreinstellungen"
+
+#: data/ui/font-manager-language-popover.ui:93
+msgid "Minimum Coverage"
+msgstr "Mindest-Anwendungsbereich"
+
+#: data/ui/font-manager-language-popover.ui:109
+msgid "90"
+msgstr "90"
+
+#: data/ui/font-manager-language-popover.ui:142
+msgid "Deselect All"
+msgstr "Alle abwählen"
+
+#: data/ui/font-manager-orthography-list.ui:73
+msgid "Clear selected filter"
+msgstr "Ausgewählten Filter leeren"
+
+#: data/ui/font-manager-preview-controls.ui:19
+msgid "Undo changes"
+msgstr "Änderungen rückgängig machen"
+
+#: data/ui/font-manager-preview-controls.ui:41
+msgid "Left Aligned"
+msgstr "Links ausgerichtet"
+
+#: data/ui/font-manager-preview-controls.ui:66
+msgid "Edit preview text"
+msgstr "Vorschautext bearbeiten"
+
+#: data/ui/font-manager-preview-controls.ui:88
+msgid "Centered"
+msgstr "Zentriert"
+
+#: data/ui/font-manager-preview-controls.ui:115
+msgid "Fill"
+msgstr "Füllen"
+
+#: data/ui/font-manager-preview-controls.ui:141
+msgid "Right Aligned"
+msgstr "Rechts ausgerichtet"
+
+#: data/ui/font-manager-preview-pane.ui:54
+msgid "Characters"
+msgstr "Zeichentabelle"
+
+#: data/ui/font-manager-preview-pane.ui:80
+msgid "Properties"
+msgstr "Eigenschaften"
+
+#: data/ui/font-manager-preview-pane.ui:119
+msgid "Select preview type"
+msgstr "Art der Vorschau auswählen"
+
+#: data/ui/font-manager-properties-pane.ui:139
+msgid "PostScript Name"
+msgstr "PostScript Name"
+
+#: data/ui/font-manager-properties-pane.ui:245
+msgid "Version"
+msgstr "Version"
+
+#: data/ui/font-manager-properties-pane.ui:281
+msgid "FileType"
+msgstr "Dateiart"
+
+#: data/ui/font-manager-properties-pane.ui:299
+msgid "Filesize"
+msgstr "Dateigröße"
+
+#: data/ui/font-manager-shortcuts-window.ui:14
+msgid "General"
+msgstr "Allgemein"
+
+#: data/ui/font-manager-shortcuts-window.ui:26
+msgid "Increase preview size"
+msgstr "Vorschaugröße vergrößern"
+
+#: data/ui/font-manager-shortcuts-window.ui:33
+msgid "Decrease preview size"
+msgstr "Vorschaugröße verkleinern"
+
+#: data/ui/font-manager-shortcuts-window.ui:40
+msgid "Reset preview size"
+msgstr "Vorschaugröße zurücksetzen"
+
+#: data/ui/font-manager-shortcuts-window.ui:47
+msgid "Reload"
+msgstr "Aktualisieren"
+
+#: data/ui/font-manager-shortcuts-window.ui:54
+msgid "Quit the application"
+msgstr "Programm beenden"
+
+#: data/ui/font-manager-shortcuts-window.ui:62
+msgid "Mode"
+msgstr "Arbeitsmodus"
+
+#: data/ui/font-manager-shortcuts-window.ui:67
+msgid "Switch to Manage mode"
+msgstr "Gehe auf Verwalten"
+
+#: data/ui/font-manager-shortcuts-window.ui:74
+msgid "Switch to Browse mode"
+msgstr "Gehe auf Stöbern"
+
+#: data/ui/font-manager-shortcuts-window.ui:81
+msgid "Switch to Compare mode"
+msgstr "Gehe auf Vergleichen"
+
+#: data/ui/font-manager-shortcuts-window.ui:89
+msgid "Preview Mode"
+msgstr "Vorschaumodus"
+
+#: data/ui/font-manager-shortcuts-window.ui:94
+msgid "Switch to Standard preview"
+msgstr "Gehe auf Standard-Vorschau"
+
+#: data/ui/font-manager-shortcuts-window.ui:101
+msgid "Switch to Waterfall preview"
+msgstr "Gehe auf Wasserfall-Vorschau"
+
+#: data/ui/font-manager-shortcuts-window.ui:108
+msgid "Switch to Body Text preview"
+msgstr "Gehe auf Textbeispiel-Vorschau"
+
+#: data/ui/font-manager-standard-sidebar.ui:24
+msgid "Categories"
+msgstr "Kategorien"
+
+#: data/ui/font-manager-standard-sidebar.ui:66
+msgid "Collections"
+msgstr "Kollektionen"
+
+#: data/ui/font-manager-subpixel-geometry.ui:44
+msgid "Subpixel Geometry"
+msgstr "Geometrie der Teilbildpunkte"
+
+#: data/ui/font-manager-substitute.ui:40
+msgid "Remove substitute"
+msgstr "Ersatz entfernen"
+
+#: data/ui/font-manager-substitute.ui:41
+msgid "Enter substitute family"
+msgstr "Familien-Ersatz eintragen"
+
+#: data/ui/font-manager-substitute.ui:58
+msgid "prefer"
+msgstr "Vorrang geben"
+
+#: data/ui/font-manager-substitute.ui:59
+msgid "accept"
+msgstr "akzeptiere"
+
+#: data/ui/font-manager-substitute.ui:60
+msgid "default"
+msgstr "standard"

--- a/po/hr.po
+++ b/po/hr.po
@@ -591,7 +591,7 @@ msgstr "Normalni"
 
 #: src/font-manager/Categories.vala:390
 msgid "Regular"
-msgstr "Normalei"
+msgstr "Normalni"
 
 #: src/font-manager/CellRendererPill.vala:58
 msgid "Variation "

--- a/po/hr.po
+++ b/po/hr.po
@@ -16,8 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Author:
-#  Jerry Casiano <JerryCasiano@gmail.com>
-# Jerry Casiano <JerryCasiano@gmail.com>, 2016. #zanata
+# Jerry Casiano <JerryCasiano@gmail.com>, 2016.
 msgid ""
 msgstr ""
 "Project-Id-Version: font-manager 0.7.5\n"
@@ -26,7 +25,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-05-31 19:07+0200\n"
+"PO-Revision-Date: 2019-07-14 15:26+0200\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: \n"
 "Language: hr\n"
@@ -138,19 +137,19 @@ msgstr "<Niski zamjenski znakovi>"
 
 #: lib/unicode/unicode-info.c:192
 msgid "<Private Use>"
-msgstr "<Područje privatne upotrebe>"
+msgstr "<Privatna upotreba>"
 
 #: lib/unicode/unicode-info.c:194
 msgid "<Plane 15 Private Use>"
-msgstr "<Ploča 15 područja za privatnu upotrebu>"
+msgstr "<Ploča 15 privatne upotrebe>"
 
 #: lib/unicode/unicode-info.c:196
 msgid "<Plane 16 Private Use>"
-msgstr "<Ploča 16 područja za privatnu upotrebu>"
+msgstr "<Ploča 16 privatne upotrebe>"
 
 #: lib/unicode/unicode-info.c:200
 msgid "<not assigned>"
-msgstr "<Nedodijeljen>"
+msgstr "<nedodijeljeno>"
 
 #: lib/unicode/unicode-info.c:217
 msgid "Other, Control"
@@ -166,7 +165,7 @@ msgstr "Ostalo, ne dodijeljeno"
 
 #: lib/unicode/unicode-info.c:223
 msgid "Other, Private Use"
-msgstr "Ostalo, privatna područje"
+msgstr "Ostalo, privatna upotreba"
 
 #: lib/unicode/unicode-info.c:225
 msgid "Other, Surrogate"
@@ -218,7 +217,7 @@ msgstr "Brojka, ostalo"
 
 #: lib/unicode/unicode-info.c:249
 msgid "Punctuation, Connector"
-msgstr "Interpunkcija, poveznik"
+msgstr "Interpunkcija, konektor"
 
 #: lib/unicode/unicode-info.c:251
 msgid "Punctuation, Dash"
@@ -262,15 +261,15 @@ msgstr "Simbol, ostalo"
 
 #: lib/unicode/unicode-info.c:271
 msgid "Separator, Line"
-msgstr "Razdvojnik, redak"
+msgstr "Razdjeljivač, crta"
 
 #: lib/unicode/unicode-info.c:273
 msgid "Separator, Paragraph"
-msgstr "Razdvojnik, odlomak"
+msgstr "Razdjeljivač, odlomak"
 
 #: lib/unicode/unicode-info.c:275
 msgid "Separator, Space"
-msgstr "Razdvojnik, razmak"
+msgstr "Razdjeljivač, razmak"
 
 #. Unicode assigns "Common" as the script name for any character not
 #. * specifically listed in Scripts.txt
@@ -280,8 +279,7 @@ msgstr "Zajednički"
 
 #: lib/vala/About.vala:29
 msgid "Simple font management for GTK+ desktop environments"
-msgstr ""
-"Jednostavan program za upravljanje fontovima u Gtk+ desktop okruženjima"
+msgstr "Jednostavno upravljanje fontovima u Gtk+ desktop okruženjima"
 
 #: lib/vala/About.vala:35
 msgid ""
@@ -305,7 +303,7 @@ msgstr ""
 "\n"
 "     Ovaj program je slobodan softver: možeš ga redistribuirati i/ili "
 "mijenjati\n"
-"     pod uvjetima GNU Opće javne licence, koju je objavila\n"
+"     pod uvjetima GNU opće javne licence, koju je objavila\n"
 "     Free Software Foundation, u 3. verziji licence ili (po izboru)\n"
 "     bilo koje novije verzije.\n"
 "\n"
@@ -314,7 +312,7 @@ msgstr ""
 "     PRODAJU ili PRIKLADNOST ZA ODREĐENU SVRHU. Pogledaj\n"
 "     GNU Opću javnu licencu za daljnje pojedinosti.\n"
 "\n"
-"     GNU Opća javna licenca se standardno pridodaje ovom programu.\n"
+"     GNU opća javna licenca je standardno pridodana ovom programu.\n"
 "\n"
 "     Ako ne, pogledaj <http://www.gnu.org/licenses/gpl-3.0.txt>.\n"
 "     "
@@ -369,15 +367,15 @@ msgstr "Tanki"
 
 #: lib/vala/FontConfig.vala:126
 msgid "Ultra-Light"
-msgstr "Ultra-Svjetli"
+msgstr "Ultra-Svijetli"
 
 #: lib/vala/FontConfig.vala:128 lib/vala/FontConfig.vala:208
 msgid "Light"
-msgstr "Svjetli"
+msgstr "Svijetli"
 
 #: lib/vala/FontConfig.vala:130
 msgid "Book"
-msgstr "Normalni"
+msgstr "Knjižni"
 
 #: lib/vala/FontConfig.vala:132 lib/vala/FontConfig.vala:186
 msgid "Medium"
@@ -385,7 +383,7 @@ msgstr "Srednji"
 
 #: lib/vala/FontConfig.vala:134
 msgid "Semi-Bold"
-msgstr "Poludebeli"
+msgstr "Polu-Debeli"
 
 #: lib/vala/FontConfig.vala:136
 msgid "Bold"
@@ -413,11 +411,11 @@ msgstr "Dvostruke širine"
 
 #: lib/vala/FontConfig.vala:164
 msgid "Monospace"
-msgstr "Neproporcionalni"
+msgstr "Jednometrični"
 
 #: lib/vala/FontConfig.vala:166
 msgid "Charcell"
-msgstr "Neproporcionalni prisiljeni"
+msgstr "Prisiljene širine"
 
 #: lib/vala/FontConfig.vala:184
 msgid "Slight"
@@ -527,7 +525,7 @@ msgstr "Metrika"
 
 #: src/font-manager/Categories.vala:338
 msgid "Grouped by font spacing"
-msgstr "Grupirani po metrikama fonta"
+msgstr "Grupirani po metrici"
 
 #: src/font-manager/Categories.vala:340
 #: data/ui/font-manager-preview-pane.ui:106
@@ -589,11 +587,11 @@ msgstr "Slikovni"
 
 #: src/font-manager/Categories.vala:385
 msgid "Normal"
-msgstr "Normalno"
+msgstr "Normalni"
 
 #: src/font-manager/Categories.vala:390
 msgid "Regular"
-msgstr "Normalno"
+msgstr "Normalei"
 
 #: src/font-manager/CellRendererPill.vala:58
 msgid "Variation "
@@ -605,7 +603,7 @@ msgstr "Varijacije"
 
 #: src/font-manager/Collections.vala:23
 msgid "Enter Collection Name"
-msgstr "Upiši ime zbirke"
+msgstr "Upiši naziv zbirke"
 
 #: src/font-manager/Collections.vala:118
 msgid "Add new collection"
@@ -726,7 +724,7 @@ msgid ""
 "\n"
 "Start search using %s to filter based on filepath."
 msgstr ""
-"Pretraživanje imena obitelji neovisno o veličini slova.\n"
+"Pretraživanje naziva obitelji fontova neovisno o veličini slova.\n"
 "\n"
 "Započni pretragu koristeći „%s” za filtriranje na temelju staze datoteke."
 
@@ -794,7 +792,7 @@ msgstr ""
 
 #: src/font-manager/Orthography.vala:228
 msgid "Update in progress"
-msgstr "Aktualiziranje je u tijeku"
+msgstr "Aktualiziranje u tijeku"
 
 #: src/font-manager/Orthography.vala:348
 msgid "Coverage"
@@ -1099,7 +1097,7 @@ msgstr "Instalirano"
 
 #: data/ui/font-manager-alias-row.ui:18
 msgid "Enter target family"
-msgstr "Upiši željenu obitelj"
+msgstr "Upiši željenu obitelj fontova"
 
 #: data/ui/font-manager-alias-row.ui:31
 msgid "Add substitute"
@@ -1174,7 +1172,7 @@ msgstr "Centrirano"
 
 #: data/ui/font-manager-preview-controls.ui:115
 msgid "Fill"
-msgstr "Ispuna"
+msgstr "Ispunjeno"
 
 #: data/ui/font-manager-preview-controls.ui:141
 msgid "Right Aligned"
@@ -1194,7 +1192,7 @@ msgstr "Odaberi vrstu pregleda"
 
 #: data/ui/font-manager-properties-pane.ui:139
 msgid "PostScript Name"
-msgstr "PostScript ime"
+msgstr "PostScript naziv"
 
 #: data/ui/font-manager-properties-pane.ui:245
 msgid "Version"
@@ -1226,7 +1224,7 @@ msgstr "Vrati izvornu veličinu pregleda"
 
 #: data/ui/font-manager-shortcuts-window.ui:47
 msgid "Reload"
-msgstr "Osvježi"
+msgstr "Aktualiziraj"
 
 #: data/ui/font-manager-shortcuts-window.ui:54
 msgid "Quit the application"


### PR DESCRIPTION
Please consider my proposed changes, especially cosidering "de_DE" issue.
IMO, "de_DE.po" file isn't needed and should/could be deleted. Instead, the more general "de" should be used (at least as long as no one comes up with a need for differentiating between german locales).