### PR TITLE
Add AORS Age ratings info

### DIFF
--- a/data/org.gnome.FontManager.appdata.xml.in.in
+++ b/data/org.gnome.FontManager.appdata.xml.in.in
@@ -83,5 +83,7 @@
     <url type="bugtracker">@PACKAGE_BUGREPORT@</url>
     <url type="translate">https://translate.zanata.org/project/view/@PACKAGE_NAME@</url>
 
+    <content_rating type="oars-1.1"/>
+
 </component>
 

--- a/data/org.gnome.FontViewer.appdata.xml.in.in
+++ b/data/org.gnome.FontViewer.appdata.xml.in.in
@@ -75,4 +75,6 @@
     <url type="bugtracker">@PACKAGE_BUGREPORT@</url>
     <url type="translate">https://translate.zanata.org/project/view/@PACKAGE_NAME@</url>
 
+    <content_rating type="oars-1.1"/>
+
 </component>


### PR DESCRIPTION
The rating itself is empty, after all, there are no age restrictions to this program. Still, an empty rating is not the same as a missing rating, so it's important for Font Manager to have an empty rating.