### PR TITLE
Add development-version of Flatpak Manifest

### DIFF
--- a/org.gnome.FontManager.yaml
+++ b/org.gnome.FontManager.yaml
@@ -1,0 +1,36 @@
+app-id: org.gnome.FontManager
+runtime: org.gnome.Platform
+runtime-version: 'master'
+sdk: org.gnome.Sdk
+
+command: font-manager
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+
+  # XDG Data/Fonts location
+  - --filesystem=xdg-data/fonts:create
+  - --persist=xdg-data/fonts
+
+  # XDG complient locations for font config
+  - --filesystem=xdg-config/fontconfig:create
+  - --persist=xdg-config/fontconfig
+
+cleanup:
+  - /app/include
+  - /app/lib/*.a
+  - /app/lib/*.la
+  - /app/lib/pkgconfig
+
+modules:
+  - name: fontmanager
+    buildsystem: meson
+    builddir: true
+    config-opts:
+      - -Dreproducible=true
+    sources:
+      - type: git
+        url: https://github.com/FontManager/font-manager.git
+


### PR DESCRIPTION
This will help with developing for Flatpak directly. With this file, you can open the project in GNOME Builder and from there, when you change the build-target, it will instantly use the script.

Possibly, you might have to run Flatpak build-init first, which looks like this:
`
flatpak build-init /home/YOUR USERNAME/.var/app/org.gnome.Builder/cache/gnome-builder/projects/font-manager/flatpak/staging/x86_64-master org.gnome.FontManager org.gnome.Sdk org.gnome.Platform
`

Give it a shot and let me know if you like this GNOME Builder integration