### PR TITLE
Russian UI localisation update

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -22,8 +22,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: font-manager 0.7.9\n"
 "Report-Msgid-Bugs-To: https://github.com/FontManager/master/issues\n"
-"POT-Creation-Date: 2020-09-20 15:48-0400\n"
-"PO-Revision-Date: 2020-11-28 21:44+0300\n"
+"POT-Creation-Date: 2020-11-28 19:07-0500\n"
+"PO-Revision-Date: 2020-11-29 15:51+0300\n"
 "Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -81,7 +81,7 @@ msgstr "Grafik;Betrachter;GNOME;GTK;Publizieren;"
 #: data/org.gnome.FontViewer.appdata.xml.in.in:9
 #: data/org.gnome.FontViewer.desktop.in.in:5
 #: data/org.gnome.FontViewer.desktop.in.in:6
-#: src/font-viewer/Application.vala:86 src/font-viewer/MainWindow.vala:23
+#: src/font-viewer/Application.vala:96 src/font-viewer/MainWindow.vala:23
 #: src/font-viewer/font-viewer-main-window.ui:41
 msgid "Font Viewer"
 msgstr "Schriften-Betrachter"
@@ -109,7 +109,7 @@ msgstr "Voll funktionsfähige Anwendung zur Vorschau von Schriftdateien"
 #: extensions/nautilus/font-manager-menu-provider.c:161
 #: extensions/nemo/font-manager-menu-provider.c:161
 #: extensions/thunar/font-manager-menu-provider.c:131
-#: src/font-manager/FontList.vala:439
+#: src/font-manager/FontList.vala:465
 msgid "Install"
 msgstr "Installieren"
 
@@ -130,156 +130,163 @@ msgid "Font Properties"
 msgstr "Eigenschaften der Schrift"
 
 #: lib/common/font-manager-font-preview.c:85
-#: src/font-manager/ui/font-manager-main-window.ui:108
+#: src/font-manager/ui/font-manager-main-window.ui:106
 msgid "Preview"
 msgstr "Vorschau"
 
 #: lib/common/font-manager-font-preview.c:87
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:241
 msgid "Waterfall"
 msgstr "Wasserfall"
 
-#: lib/common/font-manager-fontconfig.c:828
+#: lib/common/font-manager-fontconfig.c:826
+#: src/font-manager/web/google/Weight.vala:65
 msgid "Thin"
 msgstr "Fein"
 
-#: lib/common/font-manager-fontconfig.c:830
+#: lib/common/font-manager-fontconfig.c:828
 msgid "Ultra-Light"
 msgstr "Ultraleicht"
 
-#: lib/common/font-manager-fontconfig.c:832
-#: lib/common/font-manager-fontconfig.c:1185
+#: lib/common/font-manager-fontconfig.c:830
+#: lib/common/font-manager-fontconfig.c:1183
+#: src/font-manager/web/google/Weight.vala:69
 msgid "Light"
 msgstr "Leicht"
 
-#: lib/common/font-manager-fontconfig.c:834
+#: lib/common/font-manager-fontconfig.c:832
 msgid "Semi-Light"
 msgstr "Halbleicht"
 
-#: lib/common/font-manager-fontconfig.c:836
+#: lib/common/font-manager-fontconfig.c:834
 msgid "Book"
 msgstr "Buch"
 
-#: lib/common/font-manager-fontconfig.c:838
-#: lib/common/font-manager-fontconfig.c:1142
+#: lib/common/font-manager-fontconfig.c:836
+#: lib/common/font-manager-fontconfig.c:1140
+#: src/font-manager/web/google/Weight.vala:73
 msgid "Medium"
 msgstr "Medium"
 
-#: lib/common/font-manager-fontconfig.c:840
+#: lib/common/font-manager-fontconfig.c:838
 msgid "Semi-Bold"
 msgstr "Halbfett"
 
-#: lib/common/font-manager-fontconfig.c:842
+#: lib/common/font-manager-fontconfig.c:840
+#: src/font-manager/web/google/Weight.vala:77
 msgid "Bold"
 msgstr "Fett"
 
-#: lib/common/font-manager-fontconfig.c:844
+#: lib/common/font-manager-fontconfig.c:842
 msgid "Ultra-Bold"
 msgstr "Ultrafett"
 
-#: lib/common/font-manager-fontconfig.c:846
+#: lib/common/font-manager-fontconfig.c:844
 msgid "Heavy"
 msgstr "Kräftig"
 
-#: lib/common/font-manager-fontconfig.c:848
+#: lib/common/font-manager-fontconfig.c:846
 msgid "Ultra-Heavy"
 msgstr "Ultrakräftig"
 
-#: lib/common/font-manager-fontconfig.c:923
+#: lib/common/font-manager-fontconfig.c:921
+#: src/font-manager/web/google/WebFont.vala:158
 msgid "Italic"
 msgstr "Kursiv"
 
-#: lib/common/font-manager-fontconfig.c:925
+#: lib/common/font-manager-fontconfig.c:923
 msgid "Oblique"
 msgstr "Schräg"
 
-#: lib/common/font-manager-fontconfig.c:963
+#: lib/common/font-manager-fontconfig.c:961
 msgid "Ultra-Condensed"
 msgstr "Ultraschmal"
 
-#: lib/common/font-manager-fontconfig.c:965
+#: lib/common/font-manager-fontconfig.c:963
 msgid "Extra-Condensed"
 msgstr "Extraschmal"
 
-#: lib/common/font-manager-fontconfig.c:967
+#: lib/common/font-manager-fontconfig.c:965
 msgid "Condensed"
 msgstr "Schmal"
 
-#: lib/common/font-manager-fontconfig.c:969
+#: lib/common/font-manager-fontconfig.c:967
 msgid "Semi-Condensed"
 msgstr "Halbschmal"
 
-#: lib/common/font-manager-fontconfig.c:971
+#: lib/common/font-manager-fontconfig.c:969
 msgid "Semi-Expanded"
 msgstr "Halbbreit"
 
-#: lib/common/font-manager-fontconfig.c:973
+#: lib/common/font-manager-fontconfig.c:971
 msgid "Expanded"
 msgstr "Breit"
 
-#: lib/common/font-manager-fontconfig.c:975
+#: lib/common/font-manager-fontconfig.c:973
 msgid "Extra-Expanded"
 msgstr "Extrabreit"
 
-#: lib/common/font-manager-fontconfig.c:977
+#: lib/common/font-manager-fontconfig.c:975
 msgid "Ultra-Expanded"
 msgstr "Ultrabreit"
 
-#: lib/common/font-manager-fontconfig.c:1046
+#: lib/common/font-manager-fontconfig.c:1044
 msgid "Proportional"
 msgstr "Proportionale"
 
-#: lib/common/font-manager-fontconfig.c:1048
+#: lib/common/font-manager-fontconfig.c:1046
 msgid "Dual Width"
 msgstr "Doppelte Breite"
 
-#: lib/common/font-manager-fontconfig.c:1050
+#: lib/common/font-manager-fontconfig.c:1048
+#: src/font-manager/web/google/ui/google-font-filters.ui:260
 msgid "Monospace"
 msgstr "Dicktengleiche"
 
-#: lib/common/font-manager-fontconfig.c:1052
+#: lib/common/font-manager-fontconfig.c:1050
 msgid "Charcell"
 msgstr "Erzwungene Breite"
 
-#: lib/common/font-manager-fontconfig.c:1091
+#: lib/common/font-manager-fontconfig.c:1089
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: lib/common/font-manager-fontconfig.c:1093
+#: lib/common/font-manager-fontconfig.c:1091
 msgid "RGB"
 msgstr "RGB (Rot-Grün-Blau Teilbildpunktwiedergabe)"
 
-#: lib/common/font-manager-fontconfig.c:1095
+#: lib/common/font-manager-fontconfig.c:1093
 msgid "BGR"
 msgstr "BGR (Blau-Grün-Rot Teilbildpunktwiedergabe)"
 
-#: lib/common/font-manager-fontconfig.c:1097
+#: lib/common/font-manager-fontconfig.c:1095
 msgid "VRGB"
 msgstr "VRGB (Vertikale Rot-Grün-Blau Teilbildpunktwiedergabe)"
 
-#: lib/common/font-manager-fontconfig.c:1099
+#: lib/common/font-manager-fontconfig.c:1097
 msgid "VBGR"
 msgstr "VBGR (Vertikale Blau-Grün-Rot Teilbildpunktwiedergabe)"
 
-#: lib/common/font-manager-fontconfig.c:1101
-#: lib/common/font-manager-fontconfig.c:1146
-#: lib/common/font-manager-fontconfig.c:1189
+#: lib/common/font-manager-fontconfig.c:1099
+#: lib/common/font-manager-fontconfig.c:1144
+#: lib/common/font-manager-fontconfig.c:1187
 msgid "None"
 msgstr "Ohne"
 
-#: lib/common/font-manager-fontconfig.c:1140
+#: lib/common/font-manager-fontconfig.c:1138
 msgid "Slight"
 msgstr "Leicht"
 
-#: lib/common/font-manager-fontconfig.c:1144
+#: lib/common/font-manager-fontconfig.c:1142
 msgid "Full"
 msgstr "Voll"
 
-#: lib/common/font-manager-fontconfig.c:1183
-#: src/font-manager/ui/font-manager-main-window.ui:166
+#: lib/common/font-manager-fontconfig.c:1181
+#: src/font-manager/ui/font-manager-main-window.ui:164
 msgid "Default"
 msgstr "Voreingestellt"
 
-#: lib/common/font-manager-fontconfig.c:1187
+#: lib/common/font-manager-fontconfig.c:1185
 msgid "Legacy"
 msgstr "Veraltet"
 
@@ -363,7 +370,7 @@ msgstr "Eigenschaften"
 
 #: lib/common/font-manager-preview-pane.c:47
 #: lib/common/font-manager-preview-pane.c:557
-#: src/font-manager/Categories.vala:326
+#: src/font-manager/Categories.vala:397
 msgid "License"
 msgstr "Lizenz"
 
@@ -384,22 +391,22 @@ msgid "Style"
 msgstr "Stil"
 
 #: lib/common/font-manager-properties-pane.c:83
-#: src/font-manager/Categories.vala:319
+#: src/font-manager/Categories.vala:390
 msgid "Width"
 msgstr "Breite"
 
 #: lib/common/font-manager-properties-pane.c:84
-#: src/font-manager/Categories.vala:321
+#: src/font-manager/Categories.vala:392
 msgid "Slant"
 msgstr "Neigung"
 
 #: lib/common/font-manager-properties-pane.c:85
-#: src/font-manager/Categories.vala:320
+#: src/font-manager/Categories.vala:391
 msgid "Weight"
 msgstr "Stärke"
 
 #: lib/common/font-manager-properties-pane.c:86
-#: src/font-manager/Categories.vala:322
+#: src/font-manager/Categories.vala:393
 msgid "Spacing"
 msgstr "Dickte"
 
@@ -408,7 +415,7 @@ msgid "Version"
 msgstr "Version"
 
 #: lib/common/font-manager-properties-pane.c:88
-#: src/font-manager/Categories.vala:327
+#: src/font-manager/Categories.vala:398
 msgid "Vendor"
 msgstr "Hersteller"
 
@@ -420,13 +427,14 @@ msgstr "Dateiart"
 msgid "Filesize"
 msgstr "Dateigröße"
 
-#: lib/common/font-manager-properties-pane.c:213
-#: src/font-manager/Categories.vala:381
+#: lib/common/font-manager-properties-pane.c:214
+#: src/font-manager/Categories.vala:453
+#: src/font-manager/web/google/Weight.vala:71
 msgid "Regular"
 msgstr "Standard"
 
-#: lib/common/font-manager-properties-pane.c:213
-#: src/font-manager/Categories.vala:376
+#: lib/common/font-manager-properties-pane.c:214
+#: src/font-manager/Categories.vala:448
 #: src/font-manager/ui/font-manager-title-button-style.ui:42
 msgid "Normal"
 msgstr "Normal"
@@ -595,7 +603,8 @@ msgstr "Trennzeichen, Absatz"
 msgid "Separator, Space"
 msgstr "Trennzeichen, Leerzeichen"
 
-#. Unicode assigns "Common" as the script name for any character not* specifically listed in Scripts.txt
+#. Unicode assigns "Common" as the script name for any character not
+#. * specifically listed in Scripts.txt
 #: lib/unicode/unicode-info.c:702
 msgid "Common"
 msgstr "Gemeinsame"
@@ -651,87 +660,88 @@ msgstr ""
 "Copied by Zanata <copied-by-zanata@zanata.org>\n"
 "Milo Ivir <mail@milotype.de>, 2019"
 
-#: src/font-manager/Categories.vala:152 src/font-manager/Orthography.vala:182
+#: src/font-manager/Categories.vala:133 src/font-manager/Orthography.vala:201
 msgid "Update in progress"
 msgstr "Aktualisierung läuft"
 
-#: src/font-manager/Categories.vala:319
+#: src/font-manager/Categories.vala:390
 msgid "Grouped by font width"
 msgstr "Geordnet nach Schriftbreite"
 
-#: src/font-manager/Categories.vala:320
+#: src/font-manager/Categories.vala:391
 msgid "Grouped by font weight"
 msgstr "Geordnet nach Strichstärke"
 
-#: src/font-manager/Categories.vala:321
+#: src/font-manager/Categories.vala:392
 msgid "Grouped by font angle"
 msgstr "Geordnet nach Schriftwinkel"
 
-#: src/font-manager/Categories.vala:322
+#: src/font-manager/Categories.vala:393
 msgid "Grouped by font spacing"
 msgstr "Geordnet nach Dicktenart"
 
-#: src/font-manager/Categories.vala:326
+#: src/font-manager/Categories.vala:397
 msgid "Grouped by license type"
 msgstr "Geordnet nach Lizenz"
 
-#: src/font-manager/Categories.vala:327
+#: src/font-manager/Categories.vala:398
 msgid "Grouped by vendor"
 msgstr "Geordnet nach Hersteller"
 
-#: src/font-manager/Categories.vala:328
+#: src/font-manager/Categories.vala:399
 msgid "Filetype"
 msgstr "Dateityp"
 
-#: src/font-manager/Categories.vala:328
+#: src/font-manager/Categories.vala:399
 msgid "Grouped by filetype"
 msgstr "Geordnet nach Dateityp"
 
-#: src/font-manager/Categories.vala:335
+#: src/font-manager/Categories.vala:406
 msgid "All"
 msgstr "Alle"
 
-#: src/font-manager/Categories.vala:335
+#: src/font-manager/Categories.vala:406
 msgid "All Fonts"
 msgstr "Alle Schriften"
 
-#: src/font-manager/Categories.vala:336
+#: src/font-manager/Categories.vala:407
 msgid "System"
 msgstr "System"
 
-#: src/font-manager/Categories.vala:336
+#: src/font-manager/Categories.vala:407
 msgid "Fonts available to all users"
 msgstr "Für alle Benutzer verfügbare Schriften"
 
-#: src/font-manager/Categories.vala:350
+#: src/font-manager/Categories.vala:421
 msgid "Family Kind"
 msgstr "Familienart"
 
-#: src/font-manager/Categories.vala:350
+#: src/font-manager/Categories.vala:421
 msgid "Only fonts which include Panose information will be grouped here."
 msgstr "Nur Schriften mit Panose Informationen werden hier gruppiert."
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
+#: src/font-manager/web/google/ui/google-font-filters.ui:355
 msgid "Any"
 msgstr "Alle"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "No Fit"
 msgstr "Keine Übereinstimmung"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "Text and Display"
 msgstr "Text und Überschriften"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "Script"
 msgstr "Schreibschrift"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "Decorative"
 msgstr "Dekorativ"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "Pictorial"
 msgstr "Bildhaft"
 
@@ -757,28 +767,38 @@ msgstr "Neue Kollektion hinzufügen"
 msgid "Remove selected collection"
 msgstr "Ausgewählte Kollektion entfernen"
 
-#: src/font-manager/Collections.vala:417
+#: src/font-manager/Collections.vala:423
 msgid "Copy to…"
 msgstr "Kopieren nach …"
 
-#: src/font-manager/Collections.vala:418
+#: src/font-manager/Collections.vala:424
 msgid "Compress…"
 msgstr "Komprimieren …"
+
+#: src/font-manager/Compare.vala:335
+msgid "Saved Comparison"
+msgstr ""
+
+#: src/font-manager/Compare.vala:360
+msgid ""
+"Save the current comparison\n"
+"by clicking the + button"
+msgstr ""
 
 #: src/font-manager/Dialogs.vala:59
 msgid "Select executable"
 msgstr "Ausführbare Datei auswählen"
 
 #: src/font-manager/Dialogs.vala:62 src/font-manager/Dialogs.vala:77
-#: src/font-manager/UserData.vala:59
+#: src/font-manager/UserData.vala:57
 msgid "_Select"
 msgstr "Au_swählen"
 
 #: src/font-manager/Dialogs.vala:63 src/font-manager/Dialogs.vala:78
 #: src/font-manager/Dialogs.vala:95 src/font-manager/Dialogs.vala:120
-#: src/font-manager/Dialogs.vala:153 src/font-manager/Dialogs.vala:165
-#: src/font-manager/Migration.vala:55 src/font-manager/UserData.vala:37
-#: src/font-manager/UserData.vala:48 src/font-manager/UserData.vala:60
+#: src/font-manager/Dialogs.vala:157 src/font-manager/Dialogs.vala:169
+#: src/font-manager/Migration.vala:54 src/font-manager/UserData.vala:37
+#: src/font-manager/UserData.vala:48 src/font-manager/UserData.vala:58
 msgid "_Cancel"
 msgstr "_Abbrechen"
 
@@ -798,15 +818,15 @@ msgstr "_Öffnen"
 msgid "Select source folders"
 msgstr "Quellverzeichnisse auswählen"
 
-#: src/font-manager/Dialogs.vala:152 src/font-manager/Dialogs.vala:164
+#: src/font-manager/Dialogs.vala:156 src/font-manager/Dialogs.vala:168
 msgid "Select fonts to remove"
 msgstr "Schriften zum entfernen auswählen"
 
-#: src/font-manager/Dialogs.vala:154 src/font-manager/Dialogs.vala:166
+#: src/font-manager/Dialogs.vala:158 src/font-manager/Dialogs.vala:170
 msgid "_Delete"
 msgstr "_Entfernen"
 
-#: src/font-manager/Dialogs.vala:177
+#: src/font-manager/Dialogs.vala:184
 msgid "Fonts installed in your home directory will appear here."
 msgstr ""
 "In Deinem Heim-Verzeichnis installierte Schriftarten werden hier angezeigt."
@@ -816,10 +836,13 @@ msgid "Remove selected font from collection"
 msgstr "Ausgewählte Schrift aus Kollektion entfernen"
 
 #: src/font-manager/FontList.vala:48 src/font-manager/FontList.vala:68
+#: src/font-manager/web/google/FontList.vala:51
+#: src/font-manager/web/google/FontList.vala:65
 msgid "Expand all"
 msgstr "Alle ausklappen"
 
 #: src/font-manager/FontList.vala:52
+#: src/font-manager/web/google/FontList.vala:55
 msgid "Search Families…"
 msgstr "Familien durchsuchen …"
 
@@ -837,41 +860,42 @@ msgstr ""
 "Mit %s beginnen, um basierend auf den Buchstaben zu suchen."
 
 #: src/font-manager/FontList.vala:68
+#: src/font-manager/web/google/FontList.vala:65
 msgid "Collapse all"
 msgstr "Alle einklappen"
 
-#: src/font-manager/FontList.vala:440
+#: src/font-manager/FontList.vala:466
 msgid "Copy Location"
 msgstr "Dateipfad kopieren"
 
-#: src/font-manager/FontList.vala:441
+#: src/font-manager/FontList.vala:467
 msgid "Show in Folder"
 msgstr "Im Ordner zeigen"
 
 #: src/font-manager/MainWindow.vala:54
-#: src/font-manager/ui/font-manager-main-window.ui:153
+#: src/font-manager/ui/font-manager-main-window.ui:151
 msgid "Browse"
 msgstr "Durchsehen"
 
 #: src/font-manager/MainWindow.vala:56
-#: src/font-manager/ui/font-manager-main-window.ui:124
+#: src/font-manager/ui/font-manager-main-window.ui:122
 msgid "Compare"
 msgstr "Vergleichen"
 
 #: src/font-manager/MainWindow.vala:58
-#: src/font-manager/ui/font-manager-main-window.ui:137
+#: src/font-manager/ui/font-manager-main-window.ui:135
 msgid "Manage"
 msgstr "Verwalten"
 
-#: src/font-manager/Migration.vala:56
+#: src/font-manager/Migration.vala:55
 msgid "_Continue"
 msgstr "_Weiter"
 
-#: src/font-manager/Migration.vala:70
+#: src/font-manager/Migration.vala:82
 msgid "Update Required"
 msgstr "Aktualisierung wird benötigt"
 
-#: src/font-manager/Migration.vala:219
+#: src/font-manager/Migration.vala:226
 msgid ""
 "\n"
 "Font Manager has detected files from a previous installation. Some files "
@@ -898,536 +922,7 @@ msgstr ""
 "Es wird dringend empfohlen, alle wichtigen Dateien zu sichern bevor Du "
 "weitermachst.\n"
 
-#: src/font-manager/Orthographies.vala:31
-msgid "Afrikaans"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:32
-msgid "Ahom"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:33
-msgid "Aleut Cyrillic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:34
-msgid "Aleut Latin"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:35
-msgid "Arabic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:36
-msgid "Archaic Greek Letters"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:37
-msgid "Armenian"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:38
-msgid "Astronomy"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:39
-msgid "Balinese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:40
-msgid "Baltic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:41
-msgid "Bamum"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:42
-msgid "Basic Cyrillic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:43
-msgid "Basic Greek"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:44
-msgid "Basic Latin"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:45
-msgid "Surat Batak"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:46
-msgid "Bengali"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:47
-msgid "Brāhmī"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:48
-msgid "Buginese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:49
-msgid "Unified Canadian Aboriginal Syllabics"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:50
-msgid "Carian"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:51
-msgid "Catalan"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:52
-msgid "Central European"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:53
-msgid "Chakma"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:54
-msgid "Cham"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:55
-msgid "Cherokee"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:56
-msgid "Chess Symbols"
-msgstr ""
-
-#. CJK entries added manually
-#: src/font-manager/Orthographies.vala:59
-msgid "CJK Unified"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:60
-msgid "CJK Unified Extension A"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:61
-msgid "CJK Unified Extension B"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:62
-msgid "CJK Unified Extension C"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:63
-msgid "CJK Unified Extension D"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:64
-msgid "CJK Unified Extension E"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:65
-msgid "CJK Compatibility Ideographs"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:66
-msgid "CJK Compatibility Ideographs Supplement"
-msgstr ""
-
-#. End CJK entries
-#: src/font-manager/Orthographies.vala:69
-msgid "Claudian Letters"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:70
-msgid "Coptic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:71
-msgid "Currencies"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:72
-msgid "Cypriot Syllabary"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:73
-msgid "Devanagari"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:74
-msgid "Dutch"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:75
-msgid "Egyptian Hieroglyphs"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:76
-msgid "Emoticons"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:77
-msgid "Ethiopic"
-msgstr ""
-
-#. This "orthography" contains only the euro symbol...{ N_("Euro"), "Euro" },
-#: src/font-manager/Orthographies.vala:82
-msgid "Farsi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:83
-msgid "Food and Drink"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:84
-msgid "Full Cyrillic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:85
-msgid "Georgian"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:86
-msgid "Glagolitic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:87
-msgid "Gothic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:88
-msgid "Gujarati"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:89
-msgid "Gurmukhi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:90
-msgid "Korean Hangul"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:91
-msgid "Hanunó'o"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:92
-msgid "Hebrew"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:93
-#: src/font-manager/Orthographies.vala:95
-msgid "IPA"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:94
-msgid "Igbo Onwu"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:96
-msgid "Korean Jamo"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:97
-msgid "Javanese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:98
-msgid "Japanese Jinmeiyo"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:99
-msgid "Japanese Joyo"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:100
-msgid "Kaithi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:101
-msgid "Japanese Kana"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:102
-msgid "Kannada"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:103
-msgid "Kayah Li"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:104
-msgid "Kazakh"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:105
-msgid "Kharoshthi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:106
-msgid "Khmer"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:107
-msgid "Japanese Kokuji"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:108
-msgid "Lao"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:109
-msgid "Latin Ligatures"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:110
-msgid "Lepcha"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:111
-msgid "Limbu"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:112
-msgid "Linear B Ideograms"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:113
-msgid "Linear B Syllabary"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:114
-msgid "Malayalam"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:115
-msgid "Mathematical Greek"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:116
-msgid "Mathematical Latin"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:117
-msgid "Mathematical Numerals"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:118
-msgid "Mathematical Operators"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:119
-msgid "Meetei Mayak"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:120
-msgid "Mende Kikakui"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:121
-msgid "MeroiticCursive"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:122
-msgid "Meroitic Hieroglyphs"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:123
-msgid "Miao"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:124
-msgid "Mongolian"
-msgstr ""
-
-#. Medieval Unicode Font Initiative - http://folk.uib.no/hnooh/mufi/* Contains lots of duplicates, doubt many would find it useful{ N_("MUFI 3.0"), "MUFI 3.0" },
-#: src/font-manager/Orthographies.vala:131
-msgid "Myanmar"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:132
-msgid "New Tai Lue"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:133
-msgid "N’Ko"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:134
-msgid "Ogham"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:135
-msgid "Ol Chiki"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:136
-msgid "Old Italic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:137
-msgid "Old South Arabian"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:138
-msgid "Oriya"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:139
-msgid "Osmanya"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:140
-msgid "Pan African Latin"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:141
-msgid "Pashto"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:142
-msgid "Phags Pa"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:143
-msgid "Pinyin"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:144
-msgid "Polynesian"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:145
-msgid "Polytonic Greek"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:146
-msgid "Rejang"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:147
-msgid "Romanian"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:148
-msgid "Runic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:149
-msgid "Saurashtra"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:150
-msgid "Simplified Chinese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:151
-msgid "Sindhi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:152
-msgid "Sinhala"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:153
-msgid "South Korean Hanja"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:154
-msgid "Sundanese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:155
-msgid "Syloti Nagri"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:156
-msgid "Syriac"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:157
-msgid "Tai Le"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:158
-msgid "Tai Tham (Lanna)"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:159
-msgid "Tai Viet"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:160
-msgid "Tamil"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:161
-msgid "Telugu"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:162
-msgid "Thaana"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:163
-msgid "Thai"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:164
-msgid "Tibetan"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:165
-msgid "Tifinagh"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:166
-msgid "Traditional Chinese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:167
-msgid "Turkish"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:168
-msgid "Uighur"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:169
-msgid "Urdu"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:170
-msgid "Vai"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:171
-msgid "Vedic Extensions"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:172
-msgid "Venda"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:173
-msgid "Vietnamese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:174
-msgid "Western European"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:175
-msgid "Yi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:176
-msgid "Chinese Zhuyin Fuhao"
-msgstr ""
-
-#: src/font-manager/Orthography.vala:120
+#: src/font-manager/Orthography.vala:121
 msgid "Coverage"
 msgstr "Anwendungsbereich"
 
@@ -1435,70 +930,71 @@ msgstr "Anwendungsbereich"
 msgid "Supported Orthographies"
 msgstr "Unterstützte Orthografien"
 
-#: src/font-manager/TitleBar.vala:60
+#: src/font-manager/TitleBar.vala:61
 msgid "Updating Database — Fonts"
 msgstr "Aktualisierung der Datenbank — Schriften"
 
-#: src/font-manager/TitleBar.vala:62
+#: src/font-manager/TitleBar.vala:63
 msgid "Updating Database — Metadata"
 msgstr "Aktualisierung der Datenbank — Metadaten"
 
-#: src/font-manager/TitleBar.vala:64
+#: src/font-manager/TitleBar.vala:65
 msgid "Updating Database — Orthography"
 msgstr "Aktualisierung der Datenbank — Orthografie"
 
-#: src/font-manager/TitleBar.vala:79
+#: src/font-manager/TitleBar.vala:80
 msgid "Keyboard Shortcuts"
 msgstr "Tastaturkürzel"
 
-#: src/font-manager/TitleBar.vala:80
+#: src/font-manager/TitleBar.vala:81
 #: src/font-manager/ui/font-manager-shortcuts-window.ui:19
 msgid "Help"
 msgstr "Hilfe"
 
-#: src/font-manager/TitleBar.vala:81
+#: src/font-manager/TitleBar.vala:82
 msgid "About"
 msgstr "Über"
 
-#: src/font-manager/TitleBar.vala:99
+#: src/font-manager/TitleBar.vala:100
 msgid "Import"
 msgstr "Importieren"
 
-#: src/font-manager/TitleBar.vala:100 src/font-manager/UserData.vala:115
+#: src/font-manager/TitleBar.vala:101 src/font-manager/UserData.vala:130
 msgid "Export"
 msgstr "Exportieren"
 
-#: src/font-manager/TitleBar.vala:107 src/font-manager/UserData.vala:36
+#: src/font-manager/TitleBar.vala:108 src/font-manager/UserData.vala:36
 #: src/font-manager/UserData.vala:47
 msgid "User Data"
 msgstr "Benutzerdaten"
 
-#: src/font-manager/TitleBar.vala:232
+#. HAVE_WEBKIT
+#: src/font-manager/TitleBar.vala:261
 msgid "Add Fonts"
 msgstr "Schriften hinzufügen"
 
-#: src/font-manager/TitleBar.vala:233
+#: src/font-manager/TitleBar.vala:262
 msgid "Remove Fonts"
 msgstr "Schriften entfernen"
 
-#: src/font-manager/TitleBar.vala:240
-#: src/font-manager/ui/font-manager-main-window.ui:183
+#: src/font-manager/TitleBar.vala:269
+#: src/font-manager/ui/font-manager-main-window.ui:181
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/font-manager/UserData.vala:56
+#: src/font-manager/UserData.vala:54
 msgid "Select Exported Data"
 msgstr "Exportierte Daten auswählen"
 
-#: src/font-manager/Utils.vala:230
+#: src/font-manager/Utils.vala:198
 msgid "Copying files…"
 msgstr "Kopieren von Dateien …"
 
-#: src/font-manager/filters/Collection.vala:49
+#: src/font-manager/filters/Collection.vala:48
 msgid "New Collection"
 msgstr "Neue Kollektion"
 
-#: src/font-manager/filters/Collection.vala:51
+#: src/font-manager/filters/Collection.vala:50
 #, c-format
 msgid "Created : %s"
 msgstr "Erstellt : %s"
@@ -1515,9 +1011,13 @@ msgstr "Deaktivierte Schriften"
 msgid "Filter based on language support"
 msgstr "Filter, basierend auf Sprachunterstützung"
 
-#: src/font-manager/filters/LanguageFilter.vala:49
+#: src/font-manager/filters/LanguageFilter.vala:46
 msgid "Language"
 msgstr "Sprache"
+
+#: src/font-manager/filters/LanguageFilter.vala:136
+msgid "Filter Settings"
+msgstr ""
 
 #: src/font-manager/filters/Unsorted.vala:26
 msgid "Unsorted"
@@ -1591,7 +1091,7 @@ msgstr ""
 "wenn Antialiasing auf rgba gesetzt ist."
 
 #: src/font-manager/preferences/Desktop.vala:72
-#: src/font-manager/preferences/Fontconfig.vala:319
+#: src/font-manager/preferences/Fontconfig.vala:329
 msgid "Hinting"
 msgstr "Hinting"
 
@@ -1616,15 +1116,15 @@ msgstr ""
 
 #: src/font-manager/preferences/Fontconfig.vala:204
 #: src/font-manager/preferences/Fontconfig.vala:282
-#: src/font-manager/preferences/Fontconfig.vala:446
+#: src/font-manager/preferences/Fontconfig.vala:457
 msgid "Settings saved to file."
 msgstr "Einstellungen in Datei gespeichert."
 
 #: src/font-manager/preferences/Fontconfig.vala:208
 #: src/font-manager/preferences/Fontconfig.vala:286
-#: src/font-manager/preferences/Fontconfig.vala:450
+#: src/font-manager/preferences/Fontconfig.vala:461
 msgid "Removed configuration file."
-msgstr "Konfigurations-Datei entfern."
+msgstr "Einstellungsdatei wurde entfernt."
 
 #: src/font-manager/preferences/Fontconfig.vala:235
 msgid "Target DPI"
@@ -1638,56 +1138,56 @@ msgstr "Vergrößerungs-Faktor"
 msgid "LCD Filter"
 msgstr "LCD Filter"
 
-#: src/font-manager/preferences/Fontconfig.vala:318
+#: src/font-manager/preferences/Fontconfig.vala:328
 msgid "Antialias"
 msgstr "Antialias"
 
-#: src/font-manager/preferences/Fontconfig.vala:320
+#: src/font-manager/preferences/Fontconfig.vala:330
 msgid "Enable Autohinter"
 msgstr "Automatisches Hinting aktivieren"
 
-#: src/font-manager/preferences/Fontconfig.vala:329
+#: src/font-manager/preferences/Fontconfig.vala:339
 msgid "Hinting Style"
 msgstr "Hinting-Stil"
 
-#: src/font-manager/preferences/Fontconfig.vala:330
+#: src/font-manager/preferences/Fontconfig.vala:340
 msgid "Use Embedded Bitmaps"
 msgstr "Eingebaute Bitmaps benutzen"
 
-#: src/font-manager/preferences/Fontconfig.vala:332
-#: src/font-manager/preferences/Fontconfig.vala:337
+#: src/font-manager/preferences/Fontconfig.vala:342
+#: src/font-manager/preferences/Fontconfig.vala:348
 msgid " Size Restrictions "
 msgstr " Größen-Einschränkungen "
 
-#: src/font-manager/preferences/Fontconfig.vala:335
+#: src/font-manager/preferences/Fontconfig.vala:346
 msgid " Apply settings to point sizes "
 msgstr " Einstellungen auf Schriftgröße anwenden "
 
-#: src/font-manager/preferences/Fontconfig.vala:395
+#: src/font-manager/preferences/Fontconfig.vala:406
 msgid "Smaller than"
 msgstr "Kleiner als"
 
-#: src/font-manager/preferences/Fontconfig.vala:396
+#: src/font-manager/preferences/Fontconfig.vala:407
 msgid "Larger than"
 msgstr "Größer als"
 
-#: src/font-manager/preferences/Fontconfig.vala:416
+#: src/font-manager/preferences/Fontconfig.vala:427
 msgid "Add alias"
 msgstr "Alias hinzufügen"
 
-#: src/font-manager/preferences/Fontconfig.vala:417
+#: src/font-manager/preferences/Fontconfig.vala:428
 msgid "Remove selected alias"
 msgstr "Ausgewählten Alias entfernen"
 
-#: src/font-manager/preferences/Fontconfig.vala:583
+#: src/font-manager/preferences/Fontconfig.vala:599
 msgid "Font Substitutions"
 msgstr "Schrift-Ersetzungen"
 
-#: src/font-manager/preferences/Fontconfig.vala:584
+#: src/font-manager/preferences/Fontconfig.vala:600
 msgid "Easily substitute one font family for another."
 msgstr "Ersetze einfach eine Schrift-Familie mit einer anderen."
 
-#: src/font-manager/preferences/Fontconfig.vala:585
+#: src/font-manager/preferences/Fontconfig.vala:601
 msgid "To add a new substitute click the add button in the toolbar."
 msgstr ""
 "Um eine neue Ersetzung hinzuzufügen, klicke auf den Hinzufügen-Knopf in der "
@@ -1714,6 +1214,7 @@ msgid "Substitutions"
 msgstr "Ersatz"
 
 #: src/font-manager/preferences/Preferences.vala:29
+#: src/font-manager/web/google/ui/google-font-filters.ui:204
 msgid "Display"
 msgstr "Anzeige"
 
@@ -1721,7 +1222,7 @@ msgstr "Anzeige"
 msgid "Rendering"
 msgstr "Wiedergabe"
 
-#: src/font-manager/preferences/UserActions.vala:196
+#: src/font-manager/preferences/UserActions.vala:198
 msgid ""
 "Actions defined here will be added to the font list context menu.\n"
 "\n"
@@ -1731,11 +1232,11 @@ msgid ""
 "If FAMILY or STYLE are found in the argument list they will also be replaced."
 msgstr ""
 
-#: src/font-manager/preferences/UserActions.vala:212
+#: src/font-manager/preferences/UserActions.vala:214
 msgid "User Actions"
 msgstr "Benutzerbefehle"
 
-#: src/font-manager/preferences/UserActions.vala:212
+#: src/font-manager/preferences/UserActions.vala:214
 msgid "Custom context menu entries"
 msgstr "Eigene Kontextmenüeinträge"
 
@@ -1773,7 +1274,7 @@ msgstr ""
 "Optische Funktionen vom Client sind deaktiviert. Änderungen werden erst nach "
 "Neustart des Programms sichtbar."
 
-#: src/font-manager/preferences/UserSources.vala:154
+#: src/font-manager/preferences/UserSources.vala:146
 msgid ""
 "Fonts in any folders listed here will be available within the application.\n"
 "\n"
@@ -1783,23 +1284,223 @@ msgid ""
 "Note that not all environments/applications will honor these settings."
 msgstr ""
 
-#: src/font-manager/preferences/UserSources.vala:170
+#: src/font-manager/preferences/UserSources.vala:162
 #: src/font-manager/ui/font-manager-user-data.ui:131
 msgid "Font Sources"
 msgstr "Schrift-Quellen"
 
-#: src/font-manager/preferences/UserSources.vala:171
+#: src/font-manager/preferences/UserSources.vala:163
 msgid "Easily add or preview fonts without actually installing them."
 msgstr ""
 "Füge Schriften hinzu, oder siehe Dir Schriften an, ohne sie zu installieren."
 
-#: src/font-manager/preferences/UserSources.vala:172
+#: src/font-manager/preferences/UserSources.vala:164
 msgid ""
 "To add a new source simply drag a folder onto this area or click the add "
 "button in the toolbar."
 msgstr ""
 "Um eine neue Quelle hinzuzufügen, ziehe einfach einen Ordner in diesen "
 "Bereich oder klicke auf die Schaltfläche zum hinzufügen in der Symbolleiste."
+
+#: src/font-manager/web/google/FontList.vala:56
+msgid "Case insensitive search of family names."
+msgstr ""
+
+#: src/font-manager/web/google/GoogleFonts.vala:127
+msgid "Error procesing data"
+msgstr ""
+
+#: src/font-manager/web/google/GoogleFonts.vala:131
+msgid "Network Error"
+msgstr ""
+
+#: src/font-manager/web/google/GoogleFonts.vala:132
+msgid "Please check your network settings"
+msgstr ""
+
+#: src/font-manager/web/google/GoogleFonts.vala:134
+msgid "Client Error"
+msgstr ""
+
+#: src/font-manager/web/google/GoogleFonts.vala:135
+msgid ""
+"Try restarting the application. If the issue persists, please file a bug."
+msgstr ""
+
+#: src/font-manager/web/google/GoogleFonts.vala:138
+msgid "Server Error"
+msgstr ""
+
+#: src/font-manager/web/google/GoogleFonts.vala:208
+msgid "Network Offline"
+msgstr ""
+
+#: src/font-manager/web/google/GoogleFonts.vala:209
+msgid ""
+"An active internet connection is required to access the Google Fonts catalog"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:32
+msgid "Arabic"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:33
+msgid "Bengali"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:34
+msgid "Chinese (Hong Kong)"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:35
+msgid "Chinese (Simplified)"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:36
+msgid "Chinese (Traditional)"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:37
+msgid "Cyrillic"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:38
+msgid "Cyrillic Extended"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:39
+msgid "Devanagari"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:40
+msgid "Greek"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:41
+msgid "Greek Extended"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:42
+msgid "Gujarati"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:43
+msgid "Gurmukhi"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:44
+msgid "Hebrew"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:45
+msgid "Japanese"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:46
+msgid "Kannada"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:47
+msgid "Khmer"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:48
+msgid "Korean"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:49
+msgid "Latin"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:50
+msgid "Latin Extended"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:51
+msgid "Malayalam"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:52
+msgid "Myanmar"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:53
+msgid "Oriya"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:54
+msgid "Sinhala"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:55
+msgid "Tamil"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:56
+msgid "Telugu"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:57
+msgid "Thai"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:58
+msgid "Tibetan"
+msgstr ""
+
+#: src/font-manager/web/google/Language.vala:59
+msgid "Vietnamese"
+msgstr ""
+
+#: src/font-manager/web/google/PreviewPane.vala:257
+msgid "Update Family"
+msgstr "Familienart aktualisieren"
+
+#: src/font-manager/web/google/PreviewPane.vala:257
+msgid "Update Font"
+msgstr "Schriftart aktualisieren"
+
+#: src/font-manager/web/google/PreviewPane.vala:262
+msgid "Remove Family"
+msgstr "Familie entfernen"
+
+#: src/font-manager/web/google/PreviewPane.vala:262
+msgid "Remove Font"
+msgstr "Schrift entfernen"
+
+#: src/font-manager/web/google/PreviewPane.vala:267
+msgid "Download Family"
+msgstr "Familie herunterladen"
+
+#: src/font-manager/web/google/PreviewPane.vala:267
+msgid "Download Font"
+msgstr "Schrift herunterladen"
+
+#: src/font-manager/web/google/PreviewPane.vala:277
+#, c-format
+msgid "%i Language Sample Available "
+msgstr ""
+
+#: src/font-manager/web/google/PreviewPane.vala:278
+#, c-format
+msgid "%i Language Samples Available"
+msgstr ""
+
+#: src/font-manager/web/google/Weight.vala:67
+msgid "ExtraLight"
+msgstr "Ultraleicht"
+
+#: src/font-manager/web/google/Weight.vala:75
+msgid "SemiBold"
+msgstr "Halbfett"
+
+#: src/font-manager/web/google/Weight.vala:79
+msgid "ExtraBold"
+msgstr "Ultrafett"
+
+#: src/font-manager/web/google/Weight.vala:81
+msgid "Black"
+msgstr "Schwarz"
 
 #: src/font-viewer/MainWindow.vala:24
 msgid "Preview font files before installing them."
@@ -1809,23 +1510,23 @@ msgstr "Siehe Dir Schriften an, noch bevor Du sie installierst."
 msgid "To preview a font simply drag it onto this area."
 msgstr "Für eine Schriften-Vorschau, ziehe die Schrift auf dieses Feld."
 
-#: src/font-viewer/MainWindow.vala:123
+#: src/font-viewer/MainWindow.vala:119
 msgid "No file selected"
 msgstr "Keine ausgewählte Datei"
 
-#: src/font-viewer/MainWindow.vala:124
+#: src/font-viewer/MainWindow.vala:120
 msgid "Or unsupported filetype."
 msgstr "Oder nicht unterstützende Dateiarten."
 
-#: src/font-viewer/MainWindow.vala:175
+#: src/font-viewer/MainWindow.vala:171
 msgid "Newer version already installed"
 msgstr "Eine neuere Version existiert bereits"
 
-#: src/font-viewer/MainWindow.vala:177
+#: src/font-viewer/MainWindow.vala:173
 msgid "Installed"
 msgstr "Installiert"
 
-#: src/font-viewer/MainWindow.vala:180
+#: src/font-viewer/MainWindow.vala:176
 #: src/font-viewer/font-viewer-main-window.ui:55
 msgid "Install Font"
 msgstr "Schriften installieren"
@@ -1846,31 +1547,39 @@ msgstr "Rasteransicht"
 msgid "Enter Preview Text…"
 msgstr "Vorschautext eingeben …"
 
-#: src/font-manager/ui/font-manager-browse-view.ui:181
+#: src/font-manager/ui/font-manager-browse-view.ui:182
 msgid "Previous page"
 msgstr "Vorherige Seite"
 
-#: src/font-manager/ui/font-manager-browse-view.ui:209
+#: src/font-manager/ui/font-manager-browse-view.ui:210
 msgid "Next page"
 msgstr "Nächste Seite"
 
-#: src/font-manager/ui/font-manager-compare-view.ui:55
-#: src/font-manager/ui/font-manager-compare-view.ui:59
-msgid "Select background color"
-msgstr "Wähle Hintergrundfarbe"
-
-#: src/font-manager/ui/font-manager-compare-view.ui:76
-#: src/font-manager/ui/font-manager-compare-view.ui:80
-msgid "Select text color"
-msgstr "Wähle Vordergrundfarbe"
-
-#: src/font-manager/ui/font-manager-compare-view.ui:98
+#: src/font-manager/ui/font-manager-compare-view.ui:57
 msgid "Add selected font to comparison"
 msgstr "Füge ausgewählte Schrift dem Vergleich hinzu"
 
-#: src/font-manager/ui/font-manager-compare-view.ui:122
+#: src/font-manager/ui/font-manager-compare-view.ui:83
 msgid "Remove selected font from comparison"
 msgstr "Entferne ausgewählte Schrift vom Vergleich"
+
+#: src/font-manager/ui/font-manager-compare-view.ui:108
+msgid "Pinned Comparisons"
+msgstr ""
+
+#: src/font-manager/ui/font-manager-compare-view.ui:133
+#: src/font-manager/ui/font-manager-compare-view.ui:137
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:73
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:76
+msgid "Select background color"
+msgstr "Wähle Hintergrundfarbe"
+
+#: src/font-manager/ui/font-manager-compare-view.ui:154
+#: src/font-manager/ui/font-manager-compare-view.ui:158
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:90
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:93
+msgid "Select text color"
+msgstr "Wähle Vordergrundfarbe"
 
 #: src/font-manager/ui/font-manager-font-config-controls.ui:12
 msgid "Discard"
@@ -1894,21 +1603,46 @@ msgstr "Zurück"
 msgid "Search Languages…"
 msgstr "Nach der Sprache suchen …"
 
-#: src/font-manager/ui/font-manager-language-filter-settings.ui:73
+#: src/font-manager/ui/font-manager-language-filter-settings.ui:74
 msgid "Deselect All"
 msgstr "Alle abwählen"
 
-#: src/font-manager/ui/font-manager-language-filter-settings.ui:156
+#: src/font-manager/ui/font-manager-language-filter-settings.ui:154
 msgid "Minimum Coverage"
 msgstr "Mindest-Anwendungsbereich"
 
-#: src/font-manager/ui/font-manager-language-filter-settings.ui:172
+#: src/font-manager/ui/font-manager-language-filter-settings.ui:170
 msgid "90"
 msgstr "90"
 
-#: src/font-manager/ui/font-manager-orthography-list.ui:83
+# Should this be translated anyway?
+#: src/font-manager/ui/font-manager-main-window.ui:195
+msgid "Google Fonts"
+msgstr ""
+
+#: src/font-manager/ui/font-manager-orthography-list.ui:86
 msgid "Clear selected filter"
 msgstr "Ausgewählten Filter leeren"
+
+#: src/font-manager/ui/font-manager-pinned-comparisons-row.ui:26
+msgid "Created : "
+msgstr "Erstellt : "
+
+#: src/font-manager/ui/font-manager-pinned-comparisons-row.ui:63
+msgid "Some date and time"
+msgstr ""
+
+#: src/font-manager/ui/font-manager-pinned-comparisons.ui:30
+msgid "Save current comparison"
+msgstr "Gegenwärtigen Vergleich speichern"
+
+#: src/font-manager/ui/font-manager-pinned-comparisons.ui:60
+msgid "Remove selected comparison"
+msgstr "Ausgewählten Vergleich entfernen"
+
+#: src/font-manager/ui/font-manager-pinned-comparisons.ui:90
+msgid "Restore selected comparison"
+msgstr "Ausgewählten Vergleich wiederherstellen"
 
 #: src/font-manager/ui/font-manager-shortcuts-window.ui:14
 msgid "General"
@@ -1944,7 +1678,7 @@ msgstr "Gehe auf Verwalten"
 
 #: src/font-manager/ui/font-manager-shortcuts-window.ui:74
 msgid "Switch to Browse mode"
-msgstr "Gehe auf Stöbern"
+msgstr "Gehe auf Durchsehen"
 
 #: src/font-manager/ui/font-manager-shortcuts-window.ui:81
 msgid "Switch to Compare mode"
@@ -1982,7 +1716,7 @@ msgstr "Geometrie der Teilbildpunkte"
 msgid "Enter target family"
 msgstr "Gewünschte Familie eintragen"
 
-#: src/font-manager/ui/font-manager-substitute-row.ui:31
+#: src/font-manager/ui/font-manager-substitute-row.ui:32
 msgid "Add substitute"
 msgstr "Ersatz hinzufügen"
 
@@ -2015,6 +1749,7 @@ msgid "Flat"
 msgstr "Flach"
 
 #: src/font-manager/ui/font-manager-user-action-row.ui:16
+#: src/font-manager/web/google/ui/google-font-filters.ui:52
 msgid "Name"
 msgstr "Name"
 
@@ -2045,3 +1780,56 @@ msgstr "Installierte Schriften"
 #: src/font-manager/ui/font-manager-user-data.ui:189
 msgid "Custom Actions"
 msgstr "Benutzerbefehle"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:53
+msgid "Newest"
+msgstr "Neuste"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:54
+msgid "Most Popular"
+msgstr "Beliebteste"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:55
+msgid "Trending"
+msgstr "Im Trend"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:69
+msgid "Sort Order"
+msgstr "Anordnen"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:148
+msgid "Serif"
+msgstr "Mit Serife"
+
+# Grotesk?
+#: src/font-manager/web/google/ui/google-font-filters.ui:176
+msgid "Sans Serif"
+msgstr "Ohne Serife"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:232
+msgid "Handwriting"
+msgstr "Handschrift"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:282
+msgid "Category"
+msgstr "Kategorien"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:374
+msgid "4+"
+msgstr ""
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:393
+msgid "8+"
+msgstr ""
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:412
+msgid "12+"
+msgstr ""
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:443
+msgid "Variations"
+msgstr "Varianten"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:523
+msgid "Language Support"
+msgstr "Sprachunterstützung"

--- a/po/ru.po
+++ b/po/ru.po
@@ -24,21 +24,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: font-manager 0.7.9\n"
 "Report-Msgid-Bugs-To: https://github.com/FontManager/master/issues\n"
-"POT-Creation-Date: 2020-09-20 15:48-0400\n"
-"PO-Revision-Date: 2019-12-04 10:54-0500\n"
-"Last-Translator: Alexandre Prokoudine <alexandre.prokoudine@gmail.com>\n"
+"POT-Creation-Date: 2020-11-28 19:07-0500\n"
+"PO-Revision-Date: 2020-11-29 15:33+0300\n"
 "Language-Team: \n"
-"Language: ru\n"
+"Language: ru_RU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Zanata 4.6.2\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.2.4\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #: data/org.gnome.FontManager.appdata.xml.in.in:9
 #: data/org.gnome.FontManager.desktop.in.in:5
-#: data/org.gnome.FontManager.desktop.in.in:6
-#: src/font-manager/About.vala:28
+#: data/org.gnome.FontManager.desktop.in.in:6 src/font-manager/About.vala:28
 msgid "Font Manager"
 msgstr "Менеджер шрифтов"
 
@@ -82,8 +81,7 @@ msgstr "Графика;Просмотр;GNOME;GTK;Издательство;"
 #: data/org.gnome.FontViewer.appdata.xml.in.in:9
 #: data/org.gnome.FontViewer.desktop.in.in:5
 #: data/org.gnome.FontViewer.desktop.in.in:6
-#: src/font-viewer/Application.vala:86
-#: src/font-viewer/MainWindow.vala:23
+#: src/font-viewer/Application.vala:96 src/font-viewer/MainWindow.vala:23
 #: src/font-viewer/font-viewer-main-window.ui:41
 msgid "Font Viewer"
 msgstr "Программа просмотра шрифтов"
@@ -109,7 +107,7 @@ msgstr "Полнофункциональная программа просмот
 #: extensions/nautilus/font-manager-menu-provider.c:161
 #: extensions/nemo/font-manager-menu-provider.c:161
 #: extensions/thunar/font-manager-menu-provider.c:131
-#: src/font-manager/FontList.vala:439
+#: src/font-manager/FontList.vala:465
 msgid "Install"
 msgstr "Установить"
 
@@ -117,211 +115,223 @@ msgstr "Установить"
 #: extensions/nemo/font-manager-menu-provider.c:163
 #: extensions/thunar/font-manager-menu-provider.c:133
 msgid "Install the selected font file"
-msgstr ""
+msgstr "Установить выбранный шрифт"
 
 #: extensions/nautilus/font-manager-menu-provider.c:164
 #: extensions/nemo/font-manager-menu-provider.c:164
 #: extensions/thunar/font-manager-menu-provider.c:134
 msgid "Install the selected font files"
-msgstr ""
+msgstr "Установить выбранные шрифты"
 
 #: extensions/thunar/font-manager-renamer-provider.c:86
 msgid "Font Properties"
-msgstr ""
+msgstr "Свойства шрифта"
 
 #: lib/common/font-manager-font-preview.c:85
-#: src/font-manager/ui/font-manager-main-window.ui:108
+#: src/font-manager/ui/font-manager-main-window.ui:106
 msgid "Preview"
 msgstr "Предварительный просмотр"
 
 #: lib/common/font-manager-font-preview.c:87
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:241
 msgid "Waterfall"
 msgstr "Водопад"
 
-#: lib/common/font-manager-fontconfig.c:828
+#: lib/common/font-manager-fontconfig.c:826
+#: src/font-manager/web/google/Weight.vala:65
 msgid "Thin"
 msgstr "Тонкий"
 
-#: lib/common/font-manager-fontconfig.c:830
+#: lib/common/font-manager-fontconfig.c:828
 msgid "Ultra-Light"
-msgstr "Ультралегкий"
+msgstr "Ультралёгкий"
+
+#: lib/common/font-manager-fontconfig.c:830
+#: lib/common/font-manager-fontconfig.c:1183
+#: src/font-manager/web/google/Weight.vala:69
+msgid "Light"
+msgstr "Лёгкий"
 
 #: lib/common/font-manager-fontconfig.c:832
-#: lib/common/font-manager-fontconfig.c:1185
-msgid "Light"
-msgstr "Легкий"
+msgid "Semi-Light"
+msgstr "Полулёгкий"
 
 #: lib/common/font-manager-fontconfig.c:834
-msgid "Semi-Light"
-msgstr ""
+msgid "Book"
+msgstr "Книжный"
 
 #: lib/common/font-manager-fontconfig.c:836
-msgid "Book"
-msgstr "Обычный"
-
-#: lib/common/font-manager-fontconfig.c:838
-#: lib/common/font-manager-fontconfig.c:1142
+#: lib/common/font-manager-fontconfig.c:1140
+#: src/font-manager/web/google/Weight.vala:73
 msgid "Medium"
 msgstr "Средний"
 
-#: lib/common/font-manager-fontconfig.c:840
+#: lib/common/font-manager-fontconfig.c:838
 msgid "Semi-Bold"
 msgstr "Полужирный"
 
-#: lib/common/font-manager-fontconfig.c:842
+#: lib/common/font-manager-fontconfig.c:840
+#: src/font-manager/web/google/Weight.vala:77
 msgid "Bold"
 msgstr "Жирный"
 
-#: lib/common/font-manager-fontconfig.c:844
+#: lib/common/font-manager-fontconfig.c:842
 msgid "Ultra-Bold"
 msgstr "Ультражирный"
 
-#: lib/common/font-manager-fontconfig.c:846
+#: lib/common/font-manager-fontconfig.c:844
 msgid "Heavy"
-msgstr "Тяжелый"
+msgstr "Тяжёлый"
 
-#: lib/common/font-manager-fontconfig.c:848
+#: lib/common/font-manager-fontconfig.c:846
 msgid "Ultra-Heavy"
-msgstr "Ультратяжелый"
+msgstr "Ультратяжёлый"
 
-#: lib/common/font-manager-fontconfig.c:923
+#: lib/common/font-manager-fontconfig.c:921
+#: src/font-manager/web/google/WebFont.vala:158
 msgid "Italic"
 msgstr "Курсив"
 
-#: lib/common/font-manager-fontconfig.c:925
+#: lib/common/font-manager-fontconfig.c:923
 msgid "Oblique"
 msgstr "Наклонный"
 
-#: lib/common/font-manager-fontconfig.c:963
+#: lib/common/font-manager-fontconfig.c:961
 msgid "Ultra-Condensed"
 msgstr "Ультрасжатый"
 
-#: lib/common/font-manager-fontconfig.c:965
+#: lib/common/font-manager-fontconfig.c:963
 msgid "Extra-Condensed"
 msgstr "Экстрасжатый"
 
-#: lib/common/font-manager-fontconfig.c:967
+#: lib/common/font-manager-fontconfig.c:965
 msgid "Condensed"
 msgstr "Сжатый"
 
-#: lib/common/font-manager-fontconfig.c:969
+#: lib/common/font-manager-fontconfig.c:967
 msgid "Semi-Condensed"
 msgstr "Полусжатый"
 
-#: lib/common/font-manager-fontconfig.c:971
+#: lib/common/font-manager-fontconfig.c:969
 msgid "Semi-Expanded"
 msgstr "Полурасширенный"
 
-#: lib/common/font-manager-fontconfig.c:973
+#: lib/common/font-manager-fontconfig.c:971
 msgid "Expanded"
 msgstr "Расширенный"
 
-#: lib/common/font-manager-fontconfig.c:975
+#: lib/common/font-manager-fontconfig.c:973
 msgid "Extra-Expanded"
 msgstr "Экстрарасширенный"
 
-#: lib/common/font-manager-fontconfig.c:977
+#: lib/common/font-manager-fontconfig.c:975
 msgid "Ultra-Expanded"
 msgstr "Ультрарасширенный"
 
-#: lib/common/font-manager-fontconfig.c:1046
+#: lib/common/font-manager-fontconfig.c:1044
 msgid "Proportional"
 msgstr "Пропорциональный"
 
-#: lib/common/font-manager-fontconfig.c:1048
+#: lib/common/font-manager-fontconfig.c:1046
 msgid "Dual Width"
 msgstr "Двойная ширина"
 
-#: lib/common/font-manager-fontconfig.c:1050
+#: lib/common/font-manager-fontconfig.c:1048
+#: src/font-manager/web/google/ui/google-font-filters.ui:260
 msgid "Monospace"
 msgstr "Моноширинный"
 
-#: lib/common/font-manager-fontconfig.c:1052
+#: lib/common/font-manager-fontconfig.c:1050
 msgid "Charcell"
 msgstr "Фиксированный"
 
-#: lib/common/font-manager-fontconfig.c:1091
+#: lib/common/font-manager-fontconfig.c:1089
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: lib/common/font-manager-fontconfig.c:1093
+#: lib/common/font-manager-fontconfig.c:1091
 msgid "RGB"
-msgstr "RGB (красно-зелено-синий)"
+msgstr "RGB (красно-зелёно-синий)"
+
+#: lib/common/font-manager-fontconfig.c:1093
+msgid "BGR"
+msgstr "BGR (сине-зелёно-красный)"
 
 #: lib/common/font-manager-fontconfig.c:1095
-msgid "BGR"
-msgstr "BGR (сине-зелено-красный)"
+msgid "VRGB"
+msgstr "VRGB (вертикальный красно-зелёно-синий)"
 
 #: lib/common/font-manager-fontconfig.c:1097
-msgid "VRGB"
-msgstr "VRGB (вертикальный красно-зелено-синий)"
+msgid "VBGR"
+msgstr "VBGR (вертикальный сине-зелёно-красный)"
 
 #: lib/common/font-manager-fontconfig.c:1099
-msgid "VBGR"
-msgstr "VBGR (вертикальный сине-зелено-красный)"
-
-#: lib/common/font-manager-fontconfig.c:1101
-#: lib/common/font-manager-fontconfig.c:1146
-#: lib/common/font-manager-fontconfig.c:1189
+#: lib/common/font-manager-fontconfig.c:1144
+#: lib/common/font-manager-fontconfig.c:1187
 msgid "None"
 msgstr "Отсутствует"
 
-#: lib/common/font-manager-fontconfig.c:1140
+#: lib/common/font-manager-fontconfig.c:1138
 msgid "Slight"
-msgstr "Стройный"
+msgstr "Слегка"
 
-#: lib/common/font-manager-fontconfig.c:1144
+#: lib/common/font-manager-fontconfig.c:1142
 msgid "Full"
 msgstr "Полный"
 
-#: lib/common/font-manager-fontconfig.c:1183
-#: src/font-manager/ui/font-manager-main-window.ui:166
+#: lib/common/font-manager-fontconfig.c:1181
+#: src/font-manager/ui/font-manager-main-window.ui:164
 msgid "Default"
-msgstr "Нормальный"
+msgstr "По-умолчанию"
 
-#: lib/common/font-manager-fontconfig.c:1187
+#: lib/common/font-manager-fontconfig.c:1185
 msgid "Legacy"
 msgstr "Устаревший"
 
 #: lib/common/font-manager-freetype.c:294
 msgid "Restricted License Embedding"
-msgstr ""
+msgstr "Встраивание ограничено лицензией"
 
 #: lib/common/font-manager-freetype.c:296
 msgid "Preview & Print Embedding"
-msgstr ""
+msgstr "Встраивание для печати и предварительного просмотра"
 
 #: lib/common/font-manager-freetype.c:298
 msgid "Editable Embedding"
-msgstr ""
+msgstr "Редактируемое встраивание"
 
 #: lib/common/font-manager-freetype.c:300
 msgid "Preview & Print Embedding | No Subsetting"
-msgstr ""
+msgstr "Встраивание для печати и предварительного просмотра | Не подмножество"
 
 #: lib/common/font-manager-freetype.c:302
 msgid "Editable Embedding | No Subsetting"
-msgstr ""
+msgstr "Редактируемое встраивание | Не подмножество"
 
 #: lib/common/font-manager-freetype.c:304
 msgid "Preview & Print Embedding | Bitmap Embedding Only"
 msgstr ""
+"Встраивание для печати и предварительного просмотра | Только битовое "
+"встраивание"
 
 #: lib/common/font-manager-freetype.c:306
 msgid "Editable Embedding | Bitmap Embedding Only"
-msgstr ""
+msgstr "Редактируемое встраивание | Только битовое встраивание"
 
 #: lib/common/font-manager-freetype.c:308
 msgid "Preview & Print Embedding | No Subsetting | Bitmap Embedding Only"
 msgstr ""
+"Встраивание для печати и предварительного просмотра | Не подмножество | "
+"Только битовое встраивание"
 
 #: lib/common/font-manager-freetype.c:310
 msgid "Editable Embedding | No Subsetting | Bitmap Embedding Only"
 msgstr ""
+"Редактируемое встраивание | Не подмножество | Только битовое встраивание"
 
 #: lib/common/font-manager-freetype.c:312
 msgid "Installable Embedding"
-msgstr ""
+msgstr "Устанавливаемое встраивание"
 
 #: lib/common/font-manager-license-pane.c:185
 msgid "File does not contain license information."
@@ -363,13 +373,13 @@ msgstr "Свойства"
 
 #: lib/common/font-manager-preview-pane.c:47
 #: lib/common/font-manager-preview-pane.c:557
-#: src/font-manager/Categories.vala:326
+#: src/font-manager/Categories.vala:397
 msgid "License"
 msgstr "Лицензия"
 
 #: lib/common/font-manager-preview-pane.c:437
 msgid "Search available characters"
-msgstr ""
+msgstr "Искать доступные символы"
 
 #: lib/common/font-manager-properties-pane.c:80
 msgid "PostScript Name"
@@ -377,29 +387,29 @@ msgstr "Название PostScript"
 
 #: lib/common/font-manager-properties-pane.c:81
 msgid "Family"
-msgstr ""
+msgstr "Семейство"
 
 #: lib/common/font-manager-properties-pane.c:82
 msgid "Style"
-msgstr ""
+msgstr "Стиль"
 
 #: lib/common/font-manager-properties-pane.c:83
-#: src/font-manager/Categories.vala:319
+#: src/font-manager/Categories.vala:390
 msgid "Width"
 msgstr "Ширина"
 
 #: lib/common/font-manager-properties-pane.c:84
-#: src/font-manager/Categories.vala:321
+#: src/font-manager/Categories.vala:392
 msgid "Slant"
 msgstr "Наклон"
 
 #: lib/common/font-manager-properties-pane.c:85
-#: src/font-manager/Categories.vala:320
+#: src/font-manager/Categories.vala:391
 msgid "Weight"
 msgstr "Насыщенность"
 
 #: lib/common/font-manager-properties-pane.c:86
-#: src/font-manager/Categories.vala:322
+#: src/font-manager/Categories.vala:393
 msgid "Spacing"
 msgstr "Пропорции"
 
@@ -408,9 +418,9 @@ msgid "Version"
 msgstr "Версия"
 
 #: lib/common/font-manager-properties-pane.c:88
-#: src/font-manager/Categories.vala:327
+#: src/font-manager/Categories.vala:398
 msgid "Vendor"
-msgstr "Производитель"
+msgstr "Разработчик"
 
 #: lib/common/font-manager-properties-pane.c:89
 msgid "FileType"
@@ -420,19 +430,19 @@ msgstr "Тип файла"
 msgid "Filesize"
 msgstr "Размер файла"
 
-#: lib/common/font-manager-properties-pane.c:213
-#: src/font-manager/Categories.vala:381
+#: lib/common/font-manager-properties-pane.c:214
+#: src/font-manager/Categories.vala:453
+#: src/font-manager/web/google/Weight.vala:71
 msgid "Regular"
-msgstr "Обычные"
+msgstr "Обычный"
 
-#: lib/common/font-manager-properties-pane.c:213
-#: src/font-manager/Categories.vala:376
+#: lib/common/font-manager-properties-pane.c:214
+#: src/font-manager/Categories.vala:448
 #: src/font-manager/ui/font-manager-title-button-style.ui:42
 msgid "Normal"
 msgstr "Нормальный"
 
-#: lib/common/font-manager-source.c:308
-#: lib/common/font-manager-source.c:323
+#: lib/common/font-manager-source.c:308 lib/common/font-manager-source.c:323
 msgid "Source Unavailable"
 msgstr "Источник недоступен"
 
@@ -596,15 +606,14 @@ msgstr "Разделители, Абзац"
 msgid "Separator, Space"
 msgstr "Разделители, Интервал"
 
-#. Unicode assigns "Common" as the script name for any character not
-#. * specifically listed in Scripts.txt
+#. Unicode assigns "Common" as the script name for any character not* specifically listed in Scripts.txt
 #: lib/unicode/unicode-info.c:702
 msgid "Common"
 msgstr "Общее"
 
 #: src/font-manager/About.vala:30
 msgid "Simple font management for GTK+ desktop environments"
-msgstr "Простой менеджер шрифтов для сред рабочего стола Gtk+"
+msgstr "Простой менеджер шрифтов для сред рабочего стола GTK+"
 
 #: src/font-manager/About.vala:36
 msgid ""
@@ -628,103 +637,102 @@ msgstr ""
 
 #: src/font-manager/About.vala:67
 msgid "translator-credits"
-msgstr "PF4Public\n"
+msgstr ""
+"PF4Public\n"
 "Александр Прокудин"
 
-#: src/font-manager/Categories.vala:152
-#: src/font-manager/Orthography.vala:182
+#: src/font-manager/Categories.vala:133 src/font-manager/Orthography.vala:201
 msgid "Update in progress"
 msgstr "Происходит обновление"
 
-#: src/font-manager/Categories.vala:319
+#: src/font-manager/Categories.vala:390
 msgid "Grouped by font width"
 msgstr "Сгруппированные по ширине"
 
-#: src/font-manager/Categories.vala:320
+#: src/font-manager/Categories.vala:391
 msgid "Grouped by font weight"
 msgstr "Сгруппированные по насыщенности"
 
-#: src/font-manager/Categories.vala:321
+#: src/font-manager/Categories.vala:392
 msgid "Grouped by font angle"
 msgstr "Сгруппированные по наклону"
 
-#: src/font-manager/Categories.vala:322
+#: src/font-manager/Categories.vala:393
 msgid "Grouped by font spacing"
 msgstr "Сгруппированные по пропорциям"
 
-#: src/font-manager/Categories.vala:326
+#: src/font-manager/Categories.vala:397
 msgid "Grouped by license type"
 msgstr "Сгруппированные по лицензии"
 
-#: src/font-manager/Categories.vala:327
+#: src/font-manager/Categories.vala:398
 msgid "Grouped by vendor"
-msgstr "Сгруппированные по производителю"
+msgstr "Сгруппированные по разработчику"
 
-#: src/font-manager/Categories.vala:328
+#: src/font-manager/Categories.vala:399
 msgid "Filetype"
 msgstr "Тип файла"
 
-#: src/font-manager/Categories.vala:328
+#: src/font-manager/Categories.vala:399
 msgid "Grouped by filetype"
 msgstr "Сгруппированные по типу файла"
 
-#: src/font-manager/Categories.vala:335
+#: src/font-manager/Categories.vala:406
 msgid "All"
 msgstr "Все"
 
-#: src/font-manager/Categories.vala:335
+#: src/font-manager/Categories.vala:406
 msgid "All Fonts"
 msgstr "Все шрифты"
 
-#: src/font-manager/Categories.vala:336
+#: src/font-manager/Categories.vala:407
 msgid "System"
 msgstr "Системные"
 
-#: src/font-manager/Categories.vala:336
+#: src/font-manager/Categories.vala:407
 msgid "Fonts available to all users"
 msgstr "Шрифты, доступные всем пользователям"
 
-#: src/font-manager/Categories.vala:350
+#: src/font-manager/Categories.vala:421
 msgid "Family Kind"
 msgstr "Семейство"
 
-#: src/font-manager/Categories.vala:350
+#: src/font-manager/Categories.vala:421
 msgid "Only fonts which include Panose information will be grouped here."
 msgstr "Здесь сгруппированы только шрифты, имеющие информацию Panose."
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
+#: src/font-manager/web/google/ui/google-font-filters.ui:355
 msgid "Any"
-msgstr "Любой"
+msgstr "Все"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "No Fit"
 msgstr "Без категории"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "Text and Display"
-msgstr "Текст и экран"
+msgstr "Для текста и экрана"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "Script"
 msgstr "Рукописные"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "Decorative"
 msgstr "Декоративные"
 
-#: src/font-manager/Categories.vala:351
+#: src/font-manager/Categories.vala:422
 msgid "Pictorial"
 msgstr "Псевдографические"
 
 #: src/font-manager/CellRenderer.vala:90
 #, c-format
 msgid "%i Variation "
-msgstr ""
-
-#: src/font-manager/CellRenderer.vala:91
-#, c-format
-msgid "%i Variations"
-msgstr ""
+msgid_plural "%i Variations"
+msgstr[0] "%i вариант "
+msgstr[1] "%i варианта"
+msgstr[2] "%i вариантов"
 
 #: src/font-manager/Collections.vala:23
 msgid "Enter Collection Name"
@@ -738,47 +746,52 @@ msgstr "Добавить новую коллекцию"
 msgid "Remove selected collection"
 msgstr "Удалить выбранную коллекцию"
 
-#: src/font-manager/Collections.vala:417
+#: src/font-manager/Collections.vala:423
 msgid "Copy to…"
-msgstr ""
+msgstr "Копировать в …"
 
-#: src/font-manager/Collections.vala:418
+#: src/font-manager/Collections.vala:424
 msgid "Compress…"
-msgstr "Сжатие…"
+msgstr "Сжать…"
+
+#: src/font-manager/Compare.vala:335
+msgid "Saved Comparison"
+msgstr "Сохранённое сравнение"
+
+#: src/font-manager/Compare.vala:360
+msgid ""
+"Save the current comparison\n"
+"by clicking the + button"
+msgstr ""
+"Сохраните текущее сравнение,\n"
+"нажав на кнопку +"
 
 #: src/font-manager/Dialogs.vala:59
 msgid "Select executable"
-msgstr ""
+msgstr "Выберите исполнимый файл"
 
-#: src/font-manager/Dialogs.vala:62
-#: src/font-manager/Dialogs.vala:77
-#: src/font-manager/UserData.vala:59
+#: src/font-manager/Dialogs.vala:62 src/font-manager/Dialogs.vala:77
+#: src/font-manager/UserData.vala:57
 msgid "_Select"
 msgstr "_Выбрать"
 
-#: src/font-manager/Dialogs.vala:63
-#: src/font-manager/Dialogs.vala:78
-#: src/font-manager/Dialogs.vala:95
-#: src/font-manager/Dialogs.vala:120
-#: src/font-manager/Dialogs.vala:153
-#: src/font-manager/Dialogs.vala:165
-#: src/font-manager/Migration.vala:55
-#: src/font-manager/UserData.vala:37
-#: src/font-manager/UserData.vala:48
-#: src/font-manager/UserData.vala:60
+#: src/font-manager/Dialogs.vala:63 src/font-manager/Dialogs.vala:78
+#: src/font-manager/Dialogs.vala:95 src/font-manager/Dialogs.vala:120
+#: src/font-manager/Dialogs.vala:157 src/font-manager/Dialogs.vala:169
+#: src/font-manager/Migration.vala:54 src/font-manager/UserData.vala:37
+#: src/font-manager/UserData.vala:48 src/font-manager/UserData.vala:58
 msgid "_Cancel"
 msgstr "_Отменить"
 
 #: src/font-manager/Dialogs.vala:74
 msgid "Select Destination"
-msgstr "Выбрать назначение"
+msgstr "Выберите назначение"
 
 #: src/font-manager/Dialogs.vala:91
 msgid "Select files to install"
 msgstr "Выберите файлы для установки"
 
-#: src/font-manager/Dialogs.vala:94
-#: src/font-manager/Dialogs.vala:119
+#: src/font-manager/Dialogs.vala:94 src/font-manager/Dialogs.vala:119
 msgid "_Open"
 msgstr "_Открыть"
 
@@ -786,17 +799,15 @@ msgstr "_Открыть"
 msgid "Select source folders"
 msgstr "Выберите папки источников"
 
-#: src/font-manager/Dialogs.vala:152
-#: src/font-manager/Dialogs.vala:164
+#: src/font-manager/Dialogs.vala:156 src/font-manager/Dialogs.vala:168
 msgid "Select fonts to remove"
-msgstr "Выберите файлы для удаления"
+msgstr "Выберите шрифты для удаления"
 
-#: src/font-manager/Dialogs.vala:154
-#: src/font-manager/Dialogs.vala:166
+#: src/font-manager/Dialogs.vala:158 src/font-manager/Dialogs.vala:170
 msgid "_Delete"
 msgstr "_Удалить"
 
-#: src/font-manager/Dialogs.vala:177
+#: src/font-manager/Dialogs.vala:184
 msgid "Fonts installed in your home directory will appear here."
 msgstr "Шрифты, установленные в вашей домашней директории, появятся тут."
 
@@ -804,12 +815,14 @@ msgstr "Шрифты, установленные в вашей домашней 
 msgid "Remove selected font from collection"
 msgstr "Удалить выбранный шрифт из коллекции"
 
-#: src/font-manager/FontList.vala:48
-#: src/font-manager/FontList.vala:68
+#: src/font-manager/FontList.vala:48 src/font-manager/FontList.vala:68
+#: src/font-manager/web/google/FontList.vala:51
+#: src/font-manager/web/google/FontList.vala:65
 msgid "Expand all"
-msgstr "Показать все"
+msgstr "Развернуть все"
 
 #: src/font-manager/FontList.vala:52
+#: src/font-manager/web/google/FontList.vala:55
 msgid "Search Families…"
 msgstr "Поиск в семействах…"
 
@@ -821,47 +834,48 @@ msgid ""
 "Start search using %s to filter based on filepath.\n"
 "Start search using %s to filter based on characters."
 msgstr ""
-"Поиск по именам семейств без учета регистра.\n"
+"Поиск по именам семейств без учёта регистра.\n"
 "\n"
-"Начните поиск с %s, чтобы фильтровать по месторасположению.\n"
-"Начните поиск с %s, чтобы фильтровать по символам."
+"Начните поиск с «%s», чтобы фильтровать по месторасположению.\n"
+"Начните поиск с «%s», чтобы фильтровать по символам."
 
 #: src/font-manager/FontList.vala:68
+#: src/font-manager/web/google/FontList.vala:65
 msgid "Collapse all"
 msgstr "Свернуть все"
 
-#: src/font-manager/FontList.vala:440
+#: src/font-manager/FontList.vala:466
 msgid "Copy Location"
 msgstr "Копировать расположение"
 
-#: src/font-manager/FontList.vala:441
+#: src/font-manager/FontList.vala:467
 msgid "Show in Folder"
 msgstr "Показать в папке"
 
 #: src/font-manager/MainWindow.vala:54
-#: src/font-manager/ui/font-manager-main-window.ui:153
+#: src/font-manager/ui/font-manager-main-window.ui:151
 msgid "Browse"
 msgstr "Просмотр"
 
 #: src/font-manager/MainWindow.vala:56
-#: src/font-manager/ui/font-manager-main-window.ui:124
+#: src/font-manager/ui/font-manager-main-window.ui:122
 msgid "Compare"
 msgstr "Сравнение"
 
 #: src/font-manager/MainWindow.vala:58
-#: src/font-manager/ui/font-manager-main-window.ui:137
+#: src/font-manager/ui/font-manager-main-window.ui:135
 msgid "Manage"
 msgstr "Управление"
 
-#: src/font-manager/Migration.vala:56
+#: src/font-manager/Migration.vala:55
 msgid "_Continue"
 msgstr "_Продолжить"
 
-#: src/font-manager/Migration.vala:70
+#: src/font-manager/Migration.vala:82
 msgid "Update Required"
 msgstr "Требуется обновление"
 
-#: src/font-manager/Migration.vala:219
+#: src/font-manager/Migration.vala:226
 msgid ""
 "\n"
 "Font Manager has detected files from a previous installation. Some files "
@@ -887,539 +901,7 @@ msgstr ""
 "Перед продолжением строго рекомендуется сделать резервную копию всех важных "
 "файлов.\n"
 
-#: src/font-manager/Orthographies.vala:31
-msgid "Afrikaans"
-msgstr "Африкаанс"
-
-#: src/font-manager/Orthographies.vala:32
-msgid "Ahom"
-msgstr "Ахомский"
-
-#: src/font-manager/Orthographies.vala:33
-msgid "Aleut Cyrillic"
-msgstr "Алеутский, кириллица"
-
-#: src/font-manager/Orthographies.vala:34
-msgid "Aleut Latin"
-msgstr "Алеутский, латиница"
-
-#: src/font-manager/Orthographies.vala:35
-msgid "Arabic"
-msgstr "Арабский"
-
-#: src/font-manager/Orthographies.vala:36
-msgid "Archaic Greek Letters"
-msgstr "Древнегреческие буквы"
-
-#: src/font-manager/Orthographies.vala:37
-msgid "Armenian"
-msgstr "Армянский"
-
-#: src/font-manager/Orthographies.vala:38
-msgid "Astronomy"
-msgstr "Астрономия"
-
-#: src/font-manager/Orthographies.vala:39
-msgid "Balinese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:40
-msgid "Baltic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:41
-msgid "Bamum"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:42
-msgid "Basic Cyrillic"
-msgstr "Базовая кириллица"
-
-#: src/font-manager/Orthographies.vala:43
-msgid "Basic Greek"
-msgstr "Базовый греческий"
-
-#: src/font-manager/Orthographies.vala:44
-msgid "Basic Latin"
-msgstr "Базовая латиница"
-
-#: src/font-manager/Orthographies.vala:45
-msgid "Surat Batak"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:46
-msgid "Bengali"
-msgstr "Бенгальский"
-
-#: src/font-manager/Orthographies.vala:47
-msgid "Brāhmī"
-msgstr "Брахми"
-
-#: src/font-manager/Orthographies.vala:48
-msgid "Buginese"
-msgstr "Бугийский"
-
-#: src/font-manager/Orthographies.vala:49
-msgid "Unified Canadian Aboriginal Syllabics"
-msgstr "Слоговое письмо канадских аборигенов"
-
-#: src/font-manager/Orthographies.vala:50
-msgid "Carian"
-msgstr "Карийский"
-
-#: src/font-manager/Orthographies.vala:51
-msgid "Catalan"
-msgstr "Каталонский"
-
-#: src/font-manager/Orthographies.vala:52
-msgid "Central European"
-msgstr "Центрально-европейский"
-
-#: src/font-manager/Orthographies.vala:53
-msgid "Chakma"
-msgstr "Чакма"
-
-#: src/font-manager/Orthographies.vala:54
-msgid "Cham"
-msgstr "Чамский"
-
-#: src/font-manager/Orthographies.vala:55
-msgid "Cherokee"
-msgstr "Чероки"
-
-#: src/font-manager/Orthographies.vala:56
-msgid "Chess Symbols"
-msgstr "Шахматные символы"
-
-#. CJK entries added manually
-#: src/font-manager/Orthographies.vala:59
-msgid "CJK Unified"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:60
-msgid "CJK Unified Extension A"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:61
-msgid "CJK Unified Extension B"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:62
-msgid "CJK Unified Extension C"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:63
-msgid "CJK Unified Extension D"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:64
-msgid "CJK Unified Extension E"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:65
-msgid "CJK Compatibility Ideographs"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:66
-msgid "CJK Compatibility Ideographs Supplement"
-msgstr ""
-
-#. End CJK entries
-#: src/font-manager/Orthographies.vala:69
-msgid "Claudian Letters"
-msgstr "Клавдиевы буквы"
-
-#: src/font-manager/Orthographies.vala:70
-msgid "Coptic"
-msgstr "Коптский"
-
-#: src/font-manager/Orthographies.vala:71
-msgid "Currencies"
-msgstr "Знаки валют"
-
-#: src/font-manager/Orthographies.vala:72
-msgid "Cypriot Syllabary"
-msgstr "Кипрское письмо"
-
-#: src/font-manager/Orthographies.vala:73
-msgid "Devanagari"
-msgstr "Деванагари"
-
-#: src/font-manager/Orthographies.vala:74
-msgid "Dutch"
-msgstr "Голландский"
-
-#: src/font-manager/Orthographies.vala:75
-msgid "Egyptian Hieroglyphs"
-msgstr "Египетские иероглифы"
-
-#: src/font-manager/Orthographies.vala:76
-msgid "Emoticons"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:77
-msgid "Ethiopic"
-msgstr "Эфиопский"
-
-#. This "orthography" contains only the euro symbol...
-#. { N_("Euro"), "Euro" },
-#: src/font-manager/Orthographies.vala:82
-msgid "Farsi"
-msgstr "Фарси"
-
-#: src/font-manager/Orthographies.vala:83
-msgid "Food and Drink"
-msgstr "Еда и напитки"
-
-#: src/font-manager/Orthographies.vala:84
-msgid "Full Cyrillic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:85
-msgid "Georgian"
-msgstr "Грузинский"
-
-#: src/font-manager/Orthographies.vala:86
-msgid "Glagolitic"
-msgstr "Глаголица"
-
-#: src/font-manager/Orthographies.vala:87
-msgid "Gothic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:88
-msgid "Gujarati"
-msgstr "Гуджарати"
-
-#: src/font-manager/Orthographies.vala:89
-msgid "Gurmukhi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:90
-msgid "Korean Hangul"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:91
-msgid "Hanunó'o"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:92
-msgid "Hebrew"
-msgstr "Иврит"
-
-#: src/font-manager/Orthographies.vala:93
-#: src/font-manager/Orthographies.vala:95
-msgid "IPA"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:94
-msgid "Igbo Onwu"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:96
-msgid "Korean Jamo"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:97
-msgid "Javanese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:98
-msgid "Japanese Jinmeiyo"
-msgstr "Дзиммэйё кандзи"
-
-#: src/font-manager/Orthographies.vala:99
-msgid "Japanese Joyo"
-msgstr "Дзёё кандзи"
-
-#: src/font-manager/Orthographies.vala:100
-msgid "Kaithi"
-msgstr "Кайтхи"
-
-#: src/font-manager/Orthographies.vala:101
-msgid "Japanese Kana"
-msgstr "Японская кана"
-
-#: src/font-manager/Orthographies.vala:102
-msgid "Kannada"
-msgstr "Каннада"
-
-#: src/font-manager/Orthographies.vala:103
-msgid "Kayah Li"
-msgstr "Кая-ли"
-
-#: src/font-manager/Orthographies.vala:104
-msgid "Kazakh"
-msgstr "Казахский"
-
-#: src/font-manager/Orthographies.vala:105
-msgid "Kharoshthi"
-msgstr "Кхароштхи"
-
-#: src/font-manager/Orthographies.vala:106
-msgid "Khmer"
-msgstr "Кхмерский"
-
-#: src/font-manager/Orthographies.vala:107
-msgid "Japanese Kokuji"
-msgstr "Японский кокудзи"
-
-#: src/font-manager/Orthographies.vala:108
-msgid "Lao"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:109
-msgid "Latin Ligatures"
-msgstr "Лигатуры, латиница"
-
-#: src/font-manager/Orthographies.vala:110
-msgid "Lepcha"
-msgstr "Лепча"
-
-#: src/font-manager/Orthographies.vala:111
-msgid "Limbu"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:112
-msgid "Linear B Ideograms"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:113
-msgid "Linear B Syllabary"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:114
-msgid "Malayalam"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:115
-msgid "Mathematical Greek"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:116
-msgid "Mathematical Latin"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:117
-msgid "Mathematical Numerals"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:118
-msgid "Mathematical Operators"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:119
-msgid "Meetei Mayak"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:120
-msgid "Mende Kikakui"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:121
-msgid "MeroiticCursive"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:122
-msgid "Meroitic Hieroglyphs"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:123
-msgid "Miao"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:124
-msgid "Mongolian"
-msgstr ""
-
-#. Medieval Unicode Font Initiative - http://folk.uib.no/hnooh/mufi/
-#. * Contains lots of duplicates, doubt many would find it useful
-#. { N_("MUFI 3.0"), "MUFI 3.0" },
-#: src/font-manager/Orthographies.vala:131
-msgid "Myanmar"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:132
-msgid "New Tai Lue"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:133
-msgid "N’Ko"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:134
-msgid "Ogham"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:135
-msgid "Ol Chiki"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:136
-msgid "Old Italic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:137
-msgid "Old South Arabian"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:138
-msgid "Oriya"
-msgstr "Орийя"
-
-#: src/font-manager/Orthographies.vala:139
-msgid "Osmanya"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:140
-msgid "Pan African Latin"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:141
-msgid "Pashto"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:142
-msgid "Phags Pa"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:143
-msgid "Pinyin"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:144
-msgid "Polynesian"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:145
-msgid "Polytonic Greek"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:146
-msgid "Rejang"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:147
-msgid "Romanian"
-msgstr "Румынский"
-
-#: src/font-manager/Orthographies.vala:148
-msgid "Runic"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:149
-msgid "Saurashtra"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:150
-msgid "Simplified Chinese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:151
-msgid "Sindhi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:152
-msgid "Sinhala"
-msgstr "Сингальский"
-
-#: src/font-manager/Orthographies.vala:153
-msgid "South Korean Hanja"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:154
-msgid "Sundanese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:155
-msgid "Syloti Nagri"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:156
-msgid "Syriac"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:157
-msgid "Tai Le"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:158
-msgid "Tai Tham (Lanna)"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:159
-msgid "Tai Viet"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:160
-msgid "Tamil"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:161
-msgid "Telugu"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:162
-msgid "Thaana"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:163
-msgid "Thai"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:164
-msgid "Tibetan"
-msgstr "Тибетский"
-
-#: src/font-manager/Orthographies.vala:165
-msgid "Tifinagh"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:166
-msgid "Traditional Chinese"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:167
-msgid "Turkish"
-msgstr "Турецкий"
-
-#: src/font-manager/Orthographies.vala:168
-msgid "Uighur"
-msgstr "Уйгурский"
-
-#: src/font-manager/Orthographies.vala:169
-msgid "Urdu"
-msgstr "Урду"
-
-#: src/font-manager/Orthographies.vala:170
-msgid "Vai"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:171
-msgid "Vedic Extensions"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:172
-msgid "Venda"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:173
-msgid "Vietnamese"
-msgstr "Вьетнамский"
-
-#: src/font-manager/Orthographies.vala:174
-msgid "Western European"
-msgstr "Западно-европейский"
-
-#: src/font-manager/Orthographies.vala:175
-msgid "Yi"
-msgstr ""
-
-#: src/font-manager/Orthographies.vala:176
-msgid "Chinese Zhuyin Fuhao"
-msgstr ""
-
-#: src/font-manager/Orthography.vala:120
+#: src/font-manager/Orthography.vala:121
 msgid "Coverage"
 msgstr "Покрытие"
 
@@ -1427,72 +909,71 @@ msgstr "Покрытие"
 msgid "Supported Orthographies"
 msgstr "Поддерживаемая орфография"
 
-#: src/font-manager/TitleBar.vala:60
-msgid "Updating Database - Fonts"
-msgstr ""
+#: src/font-manager/TitleBar.vala:61
+msgid "Updating Database — Fonts"
+msgstr "Обновление базы данных — Шрифты"
 
-#: src/font-manager/TitleBar.vala:62
-msgid "Updating Database - Metadata"
-msgstr ""
+#: src/font-manager/TitleBar.vala:63
+msgid "Updating Database — Metadata"
+msgstr "Обновление базы данных — Метаданные"
 
-#: src/font-manager/TitleBar.vala:64
-msgid "Updating Database - Orthography"
-msgstr ""
+#: src/font-manager/TitleBar.vala:65
+msgid "Updating Database — Orthography"
+msgstr "Обновление базы данных — Орфография"
 
-#: src/font-manager/TitleBar.vala:79
+#: src/font-manager/TitleBar.vala:80
 msgid "Keyboard Shortcuts"
 msgstr "Клавиатурные сокращения"
 
-#: src/font-manager/TitleBar.vala:80
+#: src/font-manager/TitleBar.vala:81
 #: src/font-manager/ui/font-manager-shortcuts-window.ui:19
 msgid "Help"
 msgstr "Помощь"
 
-#: src/font-manager/TitleBar.vala:81
+#: src/font-manager/TitleBar.vala:82
 msgid "About"
 msgstr "О программе"
 
-#: src/font-manager/TitleBar.vala:99
+#: src/font-manager/TitleBar.vala:100
 msgid "Import"
 msgstr "Импорт"
 
-#: src/font-manager/TitleBar.vala:100
-#: src/font-manager/UserData.vala:115
+#: src/font-manager/TitleBar.vala:101 src/font-manager/UserData.vala:130
 msgid "Export"
 msgstr "Экспорт"
 
-#: src/font-manager/TitleBar.vala:107
-#: src/font-manager/UserData.vala:36
+#: src/font-manager/TitleBar.vala:108 src/font-manager/UserData.vala:36
 #: src/font-manager/UserData.vala:47
 msgid "User Data"
 msgstr "Пользовательские данные"
 
-#: src/font-manager/TitleBar.vala:232
+#. HAVE_WEBKIT
+#: src/font-manager/TitleBar.vala:261
 msgid "Add Fonts"
 msgstr "Добавить шрифты"
 
-#: src/font-manager/TitleBar.vala:233
+#: src/font-manager/TitleBar.vala:262
 msgid "Remove Fonts"
 msgstr "Удалить шрифты"
 
-#: src/font-manager/TitleBar.vala:240
-#: src/font-manager/ui/font-manager-main-window.ui:183
+#: src/font-manager/TitleBar.vala:269
+#: src/font-manager/ui/font-manager-main-window.ui:181
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/font-manager/UserData.vala:56
+#: src/font-manager/UserData.vala:54
 msgid "Select Exported Data"
-msgstr ""
+msgstr "Выберите экспортированные данные"
 
-#: src/font-manager/Utils.vala:230
+#: src/font-manager/Utils.vala:198
 msgid "Copying files…"
 msgstr "Копирование файлов…"
 
-#: src/font-manager/filters/Collection.vala:49
+#: src/font-manager/filters/Collection.vala:48
 msgid "New Collection"
 msgstr "Новая коллекция"
 
-#: src/font-manager/filters/Collection.vala:51
+#: src/font-manager/filters/Collection.vala:50
 #, c-format
 msgid "Created : %s"
 msgstr "Создана : %s"
@@ -1509,9 +990,13 @@ msgstr "Отключенные шрифты"
 msgid "Filter based on language support"
 msgstr "Фильтр по языковой поддержке"
 
-#: src/font-manager/filters/LanguageFilter.vala:49
+#: src/font-manager/filters/LanguageFilter.vala:46
 msgid "Language"
 msgstr "Язык"
+
+#: src/font-manager/filters/LanguageFilter.vala:136
+msgid "Filter Settings"
+msgstr "Настройки фильтра"
 
 #: src/font-manager/filters/Unsorted.vala:26
 msgid "Unsorted"
@@ -1585,7 +1070,7 @@ msgstr ""
 "установлено в rgba."
 
 #: src/font-manager/preferences/Desktop.vala:72
-#: src/font-manager/preferences/Fontconfig.vala:319
+#: src/font-manager/preferences/Fontconfig.vala:329
 msgid "Hinting"
 msgstr "Хинтинг"
 
@@ -1607,18 +1092,25 @@ msgid ""
 "\n"
 "Note that not all environments/applications will honor these settings."
 msgstr ""
+"Выберите сохранить, чтобы сгенерировать файл настройки fontconfig из "
+"настроек выше.\n"
+"\n"
+"Выберите отбросить, чтобы удалить файл конфигурации и вернуться к настройкам "
+"по-умолчанию.\n"
+"\n"
+"Обратите внимание, что все среды/приложения будут следовать этим настройкам."
 
 #: src/font-manager/preferences/Fontconfig.vala:204
 #: src/font-manager/preferences/Fontconfig.vala:282
-#: src/font-manager/preferences/Fontconfig.vala:446
+#: src/font-manager/preferences/Fontconfig.vala:457
 msgid "Settings saved to file."
 msgstr "Настройки сохранены в файл."
 
 #: src/font-manager/preferences/Fontconfig.vala:208
 #: src/font-manager/preferences/Fontconfig.vala:286
-#: src/font-manager/preferences/Fontconfig.vala:450
+#: src/font-manager/preferences/Fontconfig.vala:461
 msgid "Removed configuration file."
-msgstr "Файл настроек удален."
+msgstr "Файл настроек удалён."
 
 #: src/font-manager/preferences/Fontconfig.vala:235
 msgid "Target DPI"
@@ -1632,56 +1124,56 @@ msgstr "Коэффициент масштабирования"
 msgid "LCD Filter"
 msgstr "Фильтр LCD"
 
-#: src/font-manager/preferences/Fontconfig.vala:318
+#: src/font-manager/preferences/Fontconfig.vala:328
 msgid "Antialias"
 msgstr "Сглаживание"
 
-#: src/font-manager/preferences/Fontconfig.vala:320
+#: src/font-manager/preferences/Fontconfig.vala:330
 msgid "Enable Autohinter"
 msgstr "Включить автохинтинг"
 
-#: src/font-manager/preferences/Fontconfig.vala:329
+#: src/font-manager/preferences/Fontconfig.vala:339
 msgid "Hinting Style"
 msgstr "Стиль хинтинга"
 
-#: src/font-manager/preferences/Fontconfig.vala:330
+#: src/font-manager/preferences/Fontconfig.vala:340
 msgid "Use Embedded Bitmaps"
 msgstr "Использовать встроенные битовые карты"
 
-#: src/font-manager/preferences/Fontconfig.vala:332
-#: src/font-manager/preferences/Fontconfig.vala:337
+#: src/font-manager/preferences/Fontconfig.vala:342
+#: src/font-manager/preferences/Fontconfig.vala:348
 msgid " Size Restrictions "
 msgstr " Ограничения по размеру "
 
-#: src/font-manager/preferences/Fontconfig.vala:335
+#: src/font-manager/preferences/Fontconfig.vala:346
 msgid " Apply settings to point sizes "
 msgstr " Применить настройки к размеру "
 
-#: src/font-manager/preferences/Fontconfig.vala:395
+#: src/font-manager/preferences/Fontconfig.vala:406
 msgid "Smaller than"
 msgstr "Меньше чем"
 
-#: src/font-manager/preferences/Fontconfig.vala:396
+#: src/font-manager/preferences/Fontconfig.vala:407
 msgid "Larger than"
 msgstr "Больше чем"
 
-#: src/font-manager/preferences/Fontconfig.vala:416
+#: src/font-manager/preferences/Fontconfig.vala:427
 msgid "Add alias"
 msgstr "Добавить подстановку"
 
-#: src/font-manager/preferences/Fontconfig.vala:417
+#: src/font-manager/preferences/Fontconfig.vala:428
 msgid "Remove selected alias"
 msgstr "Удалить выбранную подстановку"
 
-#: src/font-manager/preferences/Fontconfig.vala:583
+#: src/font-manager/preferences/Fontconfig.vala:599
 msgid "Font Substitutions"
 msgstr "Подстановки шрифтов"
 
-#: src/font-manager/preferences/Fontconfig.vala:584
+#: src/font-manager/preferences/Fontconfig.vala:600
 msgid "Easily substitute one font family for another."
-msgstr "Легкая подстановка одного семейства шрифтов другим."
+msgstr "Лёгкая подстановка одного семейства шрифтов другим."
 
-#: src/font-manager/preferences/Fontconfig.vala:585
+#: src/font-manager/preferences/Fontconfig.vala:601
 msgid "To add a new substitute click the add button in the toolbar."
 msgstr ""
 "Для добавления подстановки необходимо нажать на кнопку «Добавить» на панели "
@@ -1701,13 +1193,14 @@ msgstr "Источники"
 
 #: src/font-manager/preferences/Preferences.vala:27
 msgid "Actions"
-msgstr ""
+msgstr "Действия"
 
 #: src/font-manager/preferences/Preferences.vala:28
 msgid "Substitutions"
 msgstr "Подстановки"
 
 #: src/font-manager/preferences/Preferences.vala:29
+#: src/font-manager/web/google/ui/google-font-filters.ui:204
 msgid "Display"
 msgstr "Экран"
 
@@ -1715,7 +1208,7 @@ msgstr "Экран"
 msgid "Rendering"
 msgstr "Отображение"
 
-#: src/font-manager/preferences/UserActions.vala:196
+#: src/font-manager/preferences/UserActions.vala:198
 msgid ""
 "Actions defined here will be added to the font list context menu.\n"
 "\n"
@@ -1723,16 +1216,23 @@ msgid ""
 "the argument list.\n"
 "To control where the filepath is inserted use FILEPATH as a placeholder.\n"
 "If FAMILY or STYLE are found in the argument list they will also be replaced."
-""
 msgstr ""
+"Определённые здесь действия будут добавлены к контекстному меню списка "
+"шрифтов.\n"
+"\n"
+"Путь к файлу будет добавлен в конец списка аргументов по-умолчанию.\n"
+"Чтобы определить, куда должен быть вставлен путь к файлу, используйте "
+"FILEPATH в нужном месте.\n"
+"Если в списке аргументов будут найдены FAMILY или STYLE, они тоже будут "
+"подставлены."
 
-#: src/font-manager/preferences/UserActions.vala:212
+#: src/font-manager/preferences/UserActions.vala:214
 msgid "User Actions"
-msgstr ""
+msgstr "Пользовательские действия"
 
-#: src/font-manager/preferences/UserActions.vala:212
+#: src/font-manager/preferences/UserActions.vala:214
 msgid "Custom context menu entries"
-msgstr ""
+msgstr "Индивидуальные элементы контекстного меню"
 
 #: src/font-manager/preferences/UserInterface.vala:62
 msgid "Wide Layout"
@@ -1768,7 +1268,7 @@ msgstr ""
 "Отрисовка на стороне клиента отключена. Изменения вступят в силу после "
 "перезапуска программы."
 
-#: src/font-manager/preferences/UserSources.vala:154
+#: src/font-manager/preferences/UserSources.vala:146
 msgid ""
 "Fonts in any folders listed here will be available within the application.\n"
 "\n"
@@ -1777,18 +1277,23 @@ msgid ""
 "\n"
 "Note that not all environments/applications will honor these settings."
 msgstr ""
+"Шрифты изо всех указанных здесь папок будут доступны в приложении.\n"
+"\n"
+"Они не будут видны другим приложениям пока источник не будет задействован.\n"
+"\n"
+"Обратите внимание, что все среды/приложения будут следовать этим настройкам."
 
-#: src/font-manager/preferences/UserSources.vala:170
+#: src/font-manager/preferences/UserSources.vala:162
 #: src/font-manager/ui/font-manager-user-data.ui:131
 msgid "Font Sources"
 msgstr "Источники шрифтов"
 
-#: src/font-manager/preferences/UserSources.vala:171
+#: src/font-manager/preferences/UserSources.vala:163
 msgid "Easily add or preview fonts without actually installing them."
 msgstr ""
-"Легкое добавление или предварительный просмотр шрифтов без их установки."
+"Лёгкое добавление или предварительный просмотр шрифтов без их установки."
 
-#: src/font-manager/preferences/UserSources.vala:172
+#: src/font-manager/preferences/UserSources.vala:164
 msgid ""
 "To add a new source simply drag a folder onto this area or click the add "
 "button in the toolbar."
@@ -1796,76 +1301,285 @@ msgstr ""
 "Для добавления нового источника просто перетащите папку в данную область или "
 "нажмите на кнопку «Добавить» на панели инструментов."
 
+#: src/font-manager/web/google/FontList.vala:56
+msgid "Case insensitive search of family names."
+msgstr "Поиск по именам семейств без учёта регистра."
+
+#: src/font-manager/web/google/GoogleFonts.vala:127
+msgid "Error procesing data"
+msgstr "Ошибка обработки данных"
+
+#: src/font-manager/web/google/GoogleFonts.vala:131
+msgid "Network Error"
+msgstr "Сетевая ошибка"
+
+#: src/font-manager/web/google/GoogleFonts.vala:132
+msgid "Please check your network settings"
+msgstr "Пожалуйста, проверьте настройки сети"
+
+#: src/font-manager/web/google/GoogleFonts.vala:134
+msgid "Client Error"
+msgstr "Ошибка клиента"
+
+#: src/font-manager/web/google/GoogleFonts.vala:135
+msgid ""
+"Try restarting the application. If the issue persists, please file a bug."
+msgstr ""
+"Попробуйте перезапустить приложение. Если проблема не исчезнет, сообщите об "
+"ошибке."
+
+#: src/font-manager/web/google/GoogleFonts.vala:138
+msgid "Server Error"
+msgstr "Ошибка сервера"
+
+#: src/font-manager/web/google/GoogleFonts.vala:208
+msgid "Network Offline"
+msgstr "Нет подключения"
+
+#: src/font-manager/web/google/GoogleFonts.vala:209
+msgid ""
+"An active internet connection is required to access the Google Fonts catalog"
+msgstr ""
+"Для доступа к каталогу Google Fonts необходимо активное сетевое подключение"
+
+#: src/font-manager/web/google/Language.vala:32
+msgid "Arabic"
+msgstr "Арабский"
+
+#: src/font-manager/web/google/Language.vala:33
+msgid "Bengali"
+msgstr "Бенгальский"
+
+#: src/font-manager/web/google/Language.vala:34
+msgid "Chinese (Hong Kong)"
+msgstr "Китайский (Гонконг)"
+
+#: src/font-manager/web/google/Language.vala:35
+msgid "Chinese (Simplified)"
+msgstr "Китайский (упрощённый)"
+
+#: src/font-manager/web/google/Language.vala:36
+msgid "Chinese (Traditional)"
+msgstr "Китайский (Традиционный)"
+
+#: src/font-manager/web/google/Language.vala:37
+msgid "Cyrillic"
+msgstr "Кириллица"
+
+#: src/font-manager/web/google/Language.vala:38
+msgid "Cyrillic Extended"
+msgstr "Расширенная кириллица"
+
+#: src/font-manager/web/google/Language.vala:39
+msgid "Devanagari"
+msgstr "Деванагари"
+
+#: src/font-manager/web/google/Language.vala:40
+msgid "Greek"
+msgstr "Греческий"
+
+#: src/font-manager/web/google/Language.vala:41
+msgid "Greek Extended"
+msgstr "Греческий расширенный"
+
+#: src/font-manager/web/google/Language.vala:42
+msgid "Gujarati"
+msgstr "Гуджарати"
+
+#: src/font-manager/web/google/Language.vala:43
+msgid "Gurmukhi"
+msgstr "Гурмукхи"
+
+#: src/font-manager/web/google/Language.vala:44
+msgid "Hebrew"
+msgstr "Иврит"
+
+#: src/font-manager/web/google/Language.vala:45
+msgid "Japanese"
+msgstr "Японский"
+
+#: src/font-manager/web/google/Language.vala:46
+msgid "Kannada"
+msgstr "Каннада"
+
+#: src/font-manager/web/google/Language.vala:47
+msgid "Khmer"
+msgstr "Кхмерский"
+
+#: src/font-manager/web/google/Language.vala:48
+msgid "Korean"
+msgstr "Корейский"
+
+#: src/font-manager/web/google/Language.vala:49
+msgid "Latin"
+msgstr "Латинский"
+
+#: src/font-manager/web/google/Language.vala:50
+msgid "Latin Extended"
+msgstr "Латинский расширенный"
+
+#: src/font-manager/web/google/Language.vala:51
+msgid "Malayalam"
+msgstr "Малаялам"
+
+#: src/font-manager/web/google/Language.vala:52
+msgid "Myanmar"
+msgstr "Мьянма"
+
+#: src/font-manager/web/google/Language.vala:53
+msgid "Oriya"
+msgstr "Орийя"
+
+#: src/font-manager/web/google/Language.vala:54
+msgid "Sinhala"
+msgstr "Сингальский"
+
+#: src/font-manager/web/google/Language.vala:55
+msgid "Tamil"
+msgstr "Тамильский"
+
+#: src/font-manager/web/google/Language.vala:56
+msgid "Telugu"
+msgstr "Телугу"
+
+#: src/font-manager/web/google/Language.vala:57
+msgid "Thai"
+msgstr "Тайский"
+
+#: src/font-manager/web/google/Language.vala:58
+msgid "Tibetan"
+msgstr "Тибетский"
+
+#: src/font-manager/web/google/Language.vala:59
+msgid "Vietnamese"
+msgstr "Вьетнамский"
+
+#: src/font-manager/web/google/PreviewPane.vala:257
+msgid "Update Family"
+msgstr "Обновить семейство"
+
+#: src/font-manager/web/google/PreviewPane.vala:257
+msgid "Update Font"
+msgstr "Обновить шрифт"
+
+#: src/font-manager/web/google/PreviewPane.vala:262
+msgid "Remove Family"
+msgstr "Удалить семейство"
+
+#: src/font-manager/web/google/PreviewPane.vala:262
+msgid "Remove Font"
+msgstr "Удалить шрифт"
+
+#: src/font-manager/web/google/PreviewPane.vala:267
+msgid "Download Family"
+msgstr "Загрузить семейство"
+
+#: src/font-manager/web/google/PreviewPane.vala:267
+msgid "Download Font"
+msgstr "Загрузить шрифт"
+
+#: src/font-manager/web/google/PreviewPane.vala:277
+#, c-format
+msgid "%i Language Sample Available "
+msgid_plural "%i Language Samples Available"
+msgstr[0] "Доступен %i языковой образец "
+msgstr[1] "Доступно %i языковых образца"
+msgstr[2] "Доступно %i языковых образцов"
+
+#: src/font-manager/web/google/Weight.vala:67
+msgid "ExtraLight"
+msgstr "Ультралёгкий"
+
+#: src/font-manager/web/google/Weight.vala:75
+msgid "SemiBold"
+msgstr "Полужирный"
+
+#: src/font-manager/web/google/Weight.vala:79
+msgid "ExtraBold"
+msgstr "Ультражирный"
+
+#: src/font-manager/web/google/Weight.vala:81
+msgid "Black"
+msgstr "Чёрный"
+
 #: src/font-viewer/MainWindow.vala:24
 msgid "Preview font files before installing them."
-msgstr "Предпросмотр файлов шрифтов перед их установкой."
+msgstr "Предварительный просмотр файлов шрифтов перед их установкой."
 
 #: src/font-viewer/MainWindow.vala:25
 msgid "To preview a font simply drag it onto this area."
 msgstr "Перетащите файл шрифта в эту область, чтобы просмотреть его."
 
-#: src/font-viewer/MainWindow.vala:123
+#: src/font-viewer/MainWindow.vala:119
 msgid "No file selected"
 msgstr "Файл не выбран"
 
-#: src/font-viewer/MainWindow.vala:124
+#: src/font-viewer/MainWindow.vala:120
 msgid "Or unsupported filetype."
 msgstr "Или формат файла не поддерживается."
 
-#: src/font-viewer/MainWindow.vala:175
+#: src/font-viewer/MainWindow.vala:171
 msgid "Newer version already installed"
 msgstr "Последняя версия программы уже установлена"
 
-#: src/font-viewer/MainWindow.vala:177
+#: src/font-viewer/MainWindow.vala:173
 msgid "Installed"
 msgstr "Установленные"
 
-#: src/font-viewer/MainWindow.vala:180
+#: src/font-viewer/MainWindow.vala:176
 #: src/font-viewer/font-viewer-main-window.ui:55
 msgid "Install Font"
 msgstr "Установить шрифт"
 
 #: lib/unicode/ui/unicode-character-map-zoom-window.ui:80
 msgid "Copy"
-msgstr ""
+msgstr "Копировать"
 
 #: src/font-manager/ui/font-manager-browse-view.ui:34
 msgid "List View"
-msgstr ""
+msgstr "Списком"
 
 #: src/font-manager/ui/font-manager-browse-view.ui:68
 msgid "Grid View"
-msgstr ""
+msgstr "Таблицей"
 
 #: src/font-manager/ui/font-manager-browse-view.ui:116
 msgid "Enter Preview Text…"
-msgstr ""
+msgstr "Введите текст предварительного просмотра…"
 
-#: src/font-manager/ui/font-manager-browse-view.ui:181
+#: src/font-manager/ui/font-manager-browse-view.ui:182
 msgid "Previous page"
-msgstr ""
+msgstr "Предыдущая страница"
 
-#: src/font-manager/ui/font-manager-browse-view.ui:209
+#: src/font-manager/ui/font-manager-browse-view.ui:210
 msgid "Next page"
 msgstr "Следующая страница"
 
-#: src/font-manager/ui/font-manager-compare-view.ui:55
-#: src/font-manager/ui/font-manager-compare-view.ui:59
-msgid "Select background color"
-msgstr "Выбрать цвет фона"
-
-#: src/font-manager/ui/font-manager-compare-view.ui:76
-#: src/font-manager/ui/font-manager-compare-view.ui:80
-msgid "Select text color"
-msgstr ""
-
-#: src/font-manager/ui/font-manager-compare-view.ui:98
+#: src/font-manager/ui/font-manager-compare-view.ui:57
 msgid "Add selected font to comparison"
 msgstr "Добавить выбранный шрифт к сравнению"
 
-#: src/font-manager/ui/font-manager-compare-view.ui:122
+#: src/font-manager/ui/font-manager-compare-view.ui:83
 msgid "Remove selected font from comparison"
 msgstr "Удалить выбранный шрифт из сравнения"
+
+#: src/font-manager/ui/font-manager-compare-view.ui:108
+msgid "Pinned Comparisons"
+msgstr "Закреплённые сравнения"
+
+#: src/font-manager/ui/font-manager-compare-view.ui:133
+#: src/font-manager/ui/font-manager-compare-view.ui:137
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:73
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:76
+msgid "Select background color"
+msgstr "Выбрать цвет фона"
+
+#: src/font-manager/ui/font-manager-compare-view.ui:154
+#: src/font-manager/ui/font-manager-compare-view.ui:158
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:90
+#: src/font-manager/web/google/ui/google-fonts-preview-pane.ui:93
+msgid "Select text color"
+msgstr "Выбрать цвет текста"
 
 #: src/font-manager/ui/font-manager-font-config-controls.ui:12
 msgid "Discard"
@@ -1889,21 +1603,47 @@ msgstr "Назад"
 msgid "Search Languages…"
 msgstr "Поиск по языкам…"
 
-#: src/font-manager/ui/font-manager-language-filter-settings.ui:73
+#: src/font-manager/ui/font-manager-language-filter-settings.ui:74
 msgid "Deselect All"
 msgstr "Снять все отметки"
 
-#: src/font-manager/ui/font-manager-language-filter-settings.ui:156
+#: src/font-manager/ui/font-manager-language-filter-settings.ui:154
 msgid "Minimum Coverage"
 msgstr "Минимальное покрытие"
 
-#: src/font-manager/ui/font-manager-language-filter-settings.ui:172
+#: src/font-manager/ui/font-manager-language-filter-settings.ui:170
 msgid "90"
 msgstr ""
 
-#: src/font-manager/ui/font-manager-orthography-list.ui:83
+# Should this be translated anyway?
+#: src/font-manager/ui/font-manager-main-window.ui:195
+msgid "Google Fonts"
+msgstr ""
+
+#: src/font-manager/ui/font-manager-orthography-list.ui:86
 msgid "Clear selected filter"
 msgstr "Очистить выбранный фильтр"
+
+#: src/font-manager/ui/font-manager-pinned-comparisons-row.ui:26
+#| msgid "Created : %s"
+msgid "Created : "
+msgstr "Создана : "
+
+#: src/font-manager/ui/font-manager-pinned-comparisons-row.ui:63
+msgid "Some date and time"
+msgstr "Дата и время"
+
+#: src/font-manager/ui/font-manager-pinned-comparisons.ui:30
+msgid "Save current comparison"
+msgstr "Сохранить текущее сравнение"
+
+#: src/font-manager/ui/font-manager-pinned-comparisons.ui:60
+msgid "Remove selected comparison"
+msgstr "Удалить выбранное сравнение"
+
+#: src/font-manager/ui/font-manager-pinned-comparisons.ui:90
+msgid "Restore selected comparison"
+msgstr "Восстановить выбранное сравнение"
 
 #: src/font-manager/ui/font-manager-shortcuts-window.ui:14
 msgid "General"
@@ -1977,7 +1717,7 @@ msgstr "Субпиксельная геометрия"
 msgid "Enter target family"
 msgstr "Введите целевое семейство"
 
-#: src/font-manager/ui/font-manager-substitute-row.ui:31
+#: src/font-manager/ui/font-manager-substitute-row.ui:32
 msgid "Add substitute"
 msgstr "Добавить подстановку"
 
@@ -2003,31 +1743,32 @@ msgstr "нормальный"
 
 #: src/font-manager/ui/font-manager-title-button-style.ui:13
 msgid "Titlebar Button Style"
-msgstr ""
+msgstr "Стиль кнопок заголовка окна"
 
 #: src/font-manager/ui/font-manager-title-button-style.ui:43
 msgid "Flat"
-msgstr ""
+msgstr "Плоский"
 
 #: src/font-manager/ui/font-manager-user-action-row.ui:16
+#: src/font-manager/web/google/ui/google-font-filters.ui:52
 msgid "Name"
-msgstr ""
+msgstr "Название"
 
 #: src/font-manager/ui/font-manager-user-action-row.ui:31
 msgid "Comment"
-msgstr ""
+msgstr "Комментарий"
 
 #: src/font-manager/ui/font-manager-user-action-row.ui:47
 msgid "Executable"
-msgstr ""
+msgstr "Исполнимый файл"
 
 #: src/font-manager/ui/font-manager-user-action-row.ui:63
 msgid "Arguments"
-msgstr ""
+msgstr "Аргументы"
 
 #: src/font-manager/ui/font-manager-user-data.ui:73
 msgid "Font Configuration"
-msgstr ""
+msgstr "Настройки шрифта"
 
 #: src/font-manager/ui/font-manager-user-data.ui:102
 msgid "Font Collections"
@@ -2039,5 +1780,374 @@ msgstr "Установленные шрифты"
 
 #: src/font-manager/ui/font-manager-user-data.ui:189
 msgid "Custom Actions"
+msgstr "Пользовательские действия"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:53
+msgid "Newest"
+msgstr "По новизне"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:54
+msgid "Most Popular"
+msgstr "По популярности"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:55
+msgid "Trending"
+msgstr "По тренду"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:69
+msgid "Sort Order"
+msgstr "Порядок сортировки"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:148
+msgid "Serif"
+msgstr "С засечками"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:176
+msgid "Sans Serif"
+msgstr "Рубленный"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:232
+msgid "Handwriting"
+msgstr "Рукописный"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:282
+#| msgid "Categories"
+msgid "Category"
+msgstr "Категории"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:374
+msgid "4+"
 msgstr ""
 
+#: src/font-manager/web/google/ui/google-font-filters.ui:393
+msgid "8+"
+msgstr ""
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:412
+msgid "12+"
+msgstr ""
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:443
+#| msgid "%i Variation "
+#| msgid_plural "%i Variations"
+msgid "Variations"
+msgstr "Вариации"
+
+#: src/font-manager/web/google/ui/google-font-filters.ui:523
+msgid "Language Support"
+msgstr "Поддержка языков"
+
+#~ msgid "Afrikaans"
+#~ msgstr "Африкаанс"
+
+#~ msgid "Ahom"
+#~ msgstr "Ахомский"
+
+#~ msgid "Aleut Cyrillic"
+#~ msgstr "Алеутский, кириллица"
+
+#~ msgid "Archaic Greek Letters"
+#~ msgstr "Древнегреческие буквы"
+
+#~ msgid "Armenian"
+#~ msgstr "Армянский"
+
+#~ msgid "Astronomy"
+#~ msgstr "Астрономия"
+
+#~ msgid "Balinese"
+#~ msgstr "Балийский"
+
+#~ msgid "Baltic"
+#~ msgstr "Балтийский"
+
+#~ msgid "Bamum"
+#~ msgstr "Бамум"
+
+#~ msgid "Basic Cyrillic"
+#~ msgstr "Базовая кириллица"
+
+#~ msgid "Basic Latin"
+#~ msgstr "Базовая латиница"
+
+#~ msgid "Surat Batak"
+#~ msgstr "Батакский"
+
+#~ msgid "Brāhmī"
+#~ msgstr "Брахми"
+
+#~ msgid "Buginese"
+#~ msgstr "Бугийский"
+
+#~ msgid "Unified Canadian Aboriginal Syllabics"
+#~ msgstr "Слоговое письмо канадских аборигенов"
+
+#~ msgid "Carian"
+#~ msgstr "Карийский"
+
+#~ msgid "Catalan"
+#~ msgstr "Каталонский"
+
+#~ msgid "Central European"
+#~ msgstr "Центрально-европейский"
+
+#~ msgid "Chakma"
+#~ msgstr "Чакма"
+
+#~ msgid "Cham"
+#~ msgstr "Чамский"
+
+#~ msgid "Cherokee"
+#~ msgstr "Чероки"
+
+#~ msgid "Chess Symbols"
+#~ msgstr "Шахматные символы"
+
+#~ msgid "CJK Unified"
+#~ msgstr "Восточноазиатские"
+
+#~ msgid "CJK Unified Extension A"
+#~ msgstr "Восточноазиатские, расширение A"
+
+#~ msgid "CJK Unified Extension B"
+#~ msgstr "Восточноазиатские, расширение B"
+
+#~ msgid "CJK Unified Extension C"
+#~ msgstr "Восточноазиатские, расширение C"
+
+#~ msgid "CJK Unified Extension D"
+#~ msgstr "Восточноазиатские, расширение D"
+
+#~ msgid "CJK Unified Extension E"
+#~ msgstr "Восточноазиатские, расширение E"
+
+#~ msgid "CJK Compatibility Ideographs"
+#~ msgstr "Восточноазиатские идеограммы совместимости"
+
+#~ msgid "CJK Compatibility Ideographs Supplement"
+#~ msgstr "Восточноазиатские идеограммы совместимости, дополнение"
+
+#~ msgid "Claudian Letters"
+#~ msgstr "Клавдиевы буквы"
+
+#~ msgid "Coptic"
+#~ msgstr "Коптский"
+
+#~ msgid "Currencies"
+#~ msgstr "Знаки валют"
+
+#~ msgid "Cypriot Syllabary"
+#~ msgstr "Кипрское письмо"
+
+#~ msgid "Dutch"
+#~ msgstr "Голландский"
+
+#~ msgid "Egyptian Hieroglyphs"
+#~ msgstr "Египетские иероглифы"
+
+#~ msgid "Emoticons"
+#~ msgstr "Эмотиконы"
+
+#~ msgid "Ethiopic"
+#~ msgstr "Эфиопский"
+
+#~ msgid "Farsi"
+#~ msgstr "Фарси"
+
+#~ msgid "Food and Drink"
+#~ msgstr "Еда и напитки"
+
+#~ msgid "Georgian"
+#~ msgstr "Грузинский"
+
+#~ msgid "Glagolitic"
+#~ msgstr "Глаголица"
+
+#~ msgid "Gothic"
+#~ msgstr "Готический"
+
+#~ msgid "Hanunó'o"
+#~ msgstr "Ханунуо"
+
+#~ msgid "IPA"
+#~ msgstr "МФА"
+
+#~ msgid "Igbo Onwu"
+#~ msgstr "Игбо"
+
+#~ msgid "Japanese Jinmeiyo"
+#~ msgstr "Дзиммэйё кандзи"
+
+#~ msgid "Japanese Joyo"
+#~ msgstr "Дзёё кандзи"
+
+#~ msgid "Kaithi"
+#~ msgstr "Кайтхи"
+
+#~ msgid "Japanese Kana"
+#~ msgstr "Японская кана"
+
+#~ msgid "Kayah Li"
+#~ msgstr "Кая-ли"
+
+#~ msgid "Kazakh"
+#~ msgstr "Казахский"
+
+#~ msgid "Kharoshthi"
+#~ msgstr "Кхароштхи"
+
+#~ msgid "Japanese Kokuji"
+#~ msgstr "Японский кокудзи"
+
+#~ msgid "Lao"
+#~ msgstr "Лаосский"
+
+#~ msgid "Latin Ligatures"
+#~ msgstr "Лигатуры, латиница"
+
+#~ msgid "Lepcha"
+#~ msgstr "Лепча"
+
+#~ msgid "Limbu"
+#~ msgstr "Лимбу"
+
+#~ msgid "Linear B Ideograms"
+#~ msgstr "Линейные идеограммы B"
+
+#~ msgid "Linear B Syllabary"
+#~ msgstr "Линейный силлабарий B"
+
+#~ msgid "Mathematical Greek"
+#~ msgstr "Математический греческий"
+
+#~ msgid "Mathematical Latin"
+#~ msgstr "Математический латинский"
+
+#~ msgid "Mathematical Numerals"
+#~ msgstr "Математические числительные"
+
+#~ msgid "Mathematical Operators"
+#~ msgstr "Математические операторы"
+
+#~ msgid "Meetei Mayak"
+#~ msgstr "Манипури"
+
+#~ msgid "Mende Kikakui"
+#~ msgstr "Кикакуи"
+
+#~ msgid "MeroiticCursive"
+#~ msgstr "Мероитский курсив"
+
+#~ msgid "Meroitic Hieroglyphs"
+#~ msgstr "Мероитские иероглифы"
+
+#~ msgid "Miao"
+#~ msgstr "Письмо Полларда"
+
+#~ msgid "Mongolian"
+#~ msgstr "Монгольский"
+
+#~ msgid "New Tai Lue"
+#~ msgstr "Новое письмо лы"
+
+#~ msgid "N’Ko"
+#~ msgstr "Нко"
+
+#~ msgid "Ogham"
+#~ msgstr "Огамическое письмо"
+
+#~ msgid "Ol Chiki"
+#~ msgstr "Ол-чики"
+
+#~ msgid "Old Italic"
+#~ msgstr "Староитальянский"
+
+#~ msgid "Old South Arabian"
+#~ msgstr "Южноаравийский"
+
+#~ msgid "Osmanya"
+#~ msgstr "Исмания"
+
+#~ msgid "Pashto"
+#~ msgstr "Пашто"
+
+#~ msgid "Phags Pa"
+#~ msgstr "Письмо Пагба-ламы"
+
+#~ msgid "Pinyin"
+#~ msgstr "Пиньинь"
+
+#~ msgid "Polynesian"
+#~ msgstr "Полинезийский"
+
+#~ msgid "Rejang"
+#~ msgstr "Реджанг"
+
+#~ msgid "Romanian"
+#~ msgstr "Румынский"
+
+#~ msgid "Runic"
+#~ msgstr "Рунный"
+
+#~ msgid "Saurashtra"
+#~ msgstr "Саураштра"
+
+#~ msgid "Simplified Chinese"
+#~ msgstr "Упрощённый китайский"
+
+#~ msgid "Sindhi"
+#~ msgstr "Синдхи"
+
+#~ msgid "South Korean Hanja"
+#~ msgstr "Южнокорейский Ханча"
+
+#~ msgid "Sundanese"
+#~ msgstr "Сунданский"
+
+#~ msgid "Syloti Nagri"
+#~ msgstr "Силхетское нагари"
+
+#~ msgid "Syriac"
+#~ msgstr "Сирийский"
+
+#~ msgid "Tai Le"
+#~ msgstr "Лы"
+
+#~ msgid "Tai Tham (Lanna)"
+#~ msgstr "Ланна"
+
+#~ msgid "Thaana"
+#~ msgstr "Тана"
+
+#~ msgid "Tifinagh"
+#~ msgstr "Древнеливийское письмо"
+
+#~ msgid "Traditional Chinese"
+#~ msgstr "Традиционный китайский"
+
+#~ msgid "Turkish"
+#~ msgstr "Турецкий"
+
+#~ msgid "Uighur"
+#~ msgstr "Уйгурский"
+
+#~ msgid "Urdu"
+#~ msgstr "Урду"
+
+#~ msgid "Vai"
+#~ msgstr "Ваи"
+
+#~ msgid "Vedic Extensions"
+#~ msgstr "Ведические расширения"
+
+#~ msgid "Venda"
+#~ msgstr "Венда"
+
+#~ msgid "Western European"
+#~ msgstr "Западно-европейский"
+
+#~ msgid "Yi"
+#~ msgstr "Носу"
+
+#~ msgid "Chinese Zhuyin Fuhao"
+#~ msgstr "Китайский чжуинь фухао"


### PR DESCRIPTION
Translated new strings, but there are issues:
* Zanata seems to spoil plurals. You should do something about it. See here: https://github.com/FontManager/font-manager/commit/fc09a43c475ca03d52b6f451c62c96c22a00e334#diff-92817e54c697fd6395db7e9eca8f2468538e83db228823136eaa96d834d74f76L34-L38
* Unfortunately not all of the new strings are applied:
![image](https://user-images.githubusercontent.com/10319700/100526068-b0913200-31d6-11eb-8836-f981a614f396.png) I suppose, that strings need to be updated to correspond to source changes and then we need to review translations once again. I did a quick googling, but ufortunately couldn't find any information on how it should be done with meson, so could not perform it myself.

This probably also applies to my recent German translations. And also highly likely to recent Dutch translation.

How do we proceed?