### PR TITLE
Add syntax highlighting to code blocks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you would like to help this application reach more users in their native lang
 
 Arch Linux users can install [`font-manager`](https://archlinux.org/packages/community/x86_64/font-manager/) from official repositories:
 
-```
+```bash
 pacman -S font-manager
 ```
 
@@ -61,7 +61,7 @@ pacman -S font-manager
 
 Fedora packages built from latest revision:
 
-```
+```bash
 dnf copr enable jerrycasiano/FontManager
 dnf install font-manager
 ```
@@ -73,7 +73,7 @@ Gentoo users may find [`font-manager`](https://github.com/PF4Public/gentoo-overl
 #### Ubuntu Personal Package Archive
 Ubuntu packages built from latest revision:
 
-```
+```bash
 sudo add-apt-repository ppa:font-manager/staging
 sudo apt-get update
 sudo apt-get install font-manager
@@ -117,7 +117,7 @@ If you wish to also build Google Fonts integration, which is enabled by default,
 
 To build the application:
 
-```
+```bash
 meson --prefix=/usr --buildtype=release build
 cd build
 ninja
@@ -125,31 +125,31 @@ ninja
 
 To run the application without installing:
 
-```
+```bash
 src/font-manager/font-manager
 ```
 
 To install the application:
 
-```
+```bash
 sudo ninja install
 ```
 
 To uninstall:
 
-```
+```bash
 sudo ninja uninstall
 ```
 
 For a list of available build options:
 
-```
+```bash
 meson configure
 ```
 
 To change an option after the build directory has been configured:
 
-```
+```bash
 meson configure -Dsome_option=true
 ```
 

--- a/README.ro.md
+++ b/README.ro.md
@@ -47,7 +47,7 @@ Dacă aţi dori să ajutaţi această aplicaţie să ajungă la mai mulţi utili
 
 Utilizatorii Arch Linux pot instala [`font-manager`](https://archlinux.org/packages/community/x86_64/font-manager/) din depozitele oficiale:
 
-```
+```bash
 pacman -S font-manager
 ```
 
@@ -56,7 +56,7 @@ pacman -S font-manager
 [![Copr build status](https://copr.fedorainfracloud.org/coprs/jerrycasiano/FontManager/package/font-manager/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/jerrycasiano/FontManager/package/font-manager/)
 
 Pachete Fedora construite din ultima revizie:
-```
+```bash
 dnf copr enable jerrycasiano/FontManager
 dnf install font-manager
 ```
@@ -67,7 +67,7 @@ Utilizatorii Gentoo pot găsi [`font-manager`](https://github.com/PF4Public/gent
 
 #### Ubuntu Personal Package Archive
 Pakete Ubuntu cunstruite din ultima revizie:
-```
+```bash
 sudo add-apt-repository ppa:font-manager/staging
 sudo apt-get update
 sudo apt-get install font-manager
@@ -111,7 +111,7 @@ Dacă doriţi să construiţi şi integrare cu Google Fonts, care este activată
 
 Pentru a construi aplicaţia:
 
-```
+```bash
 meson --prefix=/usr --buildtype=release build
 cd build
 ninja
@@ -119,31 +119,31 @@ ninja
 
 Penru a rula aplicaţia fără a o instala:
 
-```
+```bash
 src/font-manager/font-manager
 ```
 
 Pentru a instala aplicaţia:
 
-```
+```bash
 sudo ninja install
 ```
 
 Pentru dezinstalare:
 
-```
+```bash
 sudo ninja uninstall
 ```
 
 Pentru o listă cu opţiunile de construire disponibile:
 
-```
+```bash
 meson configure
 ```
 
 Penru a schimba o opţiune după ce directorul de construcţie a fost configurat:
 
-```
+```bash
 meson configure -Dsome_option=true
 ```
 


### PR DESCRIPTION
This PR adds ```Bash``` syntax highlighting to code blocks inside this project's Readme.