### PR TITLE
feat: *.desktop - add mime-types - font/sfnt, application/vnd.ms-opentype

### DIFF
--- a/data/org.gnome.FontManager.desktop.in.in
+++ b/data/org.gnome.FontManager.desktop.in.in
@@ -9,7 +9,7 @@ Icon=org.gnome.FontManager
 DBusActivatable=true
 Exec=@PACKAGE_NAME@ %u
 Terminal=false
-MimeType=font/ttf;font/ttc;font/otf;application/x-font-ttf;application/x-font-otf;
+MimeType=font/ttf;font/ttc;font/otf;font/sfnt;application/x-font-ttf;application/x-font-otf;application/vnd.ms-opentype;
 Categories=Utility;GTK;GNOME;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=Graphics;Viewer;GNOME;GTK;Publishing;

--- a/data/org.gnome.FontViewer.desktop.in.in
+++ b/data/org.gnome.FontViewer.desktop.in.in
@@ -9,7 +9,7 @@ Icon=org.gnome.FontViewer
 DBusActivatable=true
 Exec=@PKGLIBEXECDIR@/font-viewer %u
 Terminal=false
-MimeType=font/ttf;font/ttc;font/otf;application/x-font-ttf;application/x-font-otf;
+MimeType=font/ttf;font/ttc;font/otf;font/sfnt;application/x-font-ttf;application/x-font-otf;application/vnd.ms-opentype;
 Categories=Utility;GTK;GNOME;
 # Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 Keywords=Graphics;Viewer;GNOME;GTK;Publishing;


### PR DESCRIPTION
I noticed that `xdg-open` (which calls `mime`) on Arch Linux in v0.8.8 won't associate fonts of MIME type `font/sfnt` and `application/vnd.ms-opentype` with the Font Viewer, while the Font Viewer can actually display them, and the Font Manager indexes them as well.

In this PR I have added these 2 mime-types to the .desktop files, so the `xdg-open` associates them.