### PR TITLE
FreeBSD's stack protector detects stack overflow in font_manager_preview_pane_update_metadata()

### DIFF
--- a/lib/gtk/font-manager-preview-pane.c
+++ b/lib/gtk/font-manager-preview-pane.c
@@ -404,7 +404,7 @@ font_manager_preview_pane_update_metadata (FontManagerPreviewPane *self)
     g_autoptr(JsonObject) res = NULL;
     if (!self->db)
         self->db = font_manager_database_new();
-    g_object_get(G_OBJECT(self->font), "filepath", &filepath, "findex", &index, NULL);
+    g_object_get(G_OBJECT(self->font), "filepath", filepath, "findex", &index, NULL);
     if (error == NULL) {
         const gchar *select = "SELECT * FROM Metadata WHERE filepath = %s AND findex = '%i'";
         char *path = sqlite3_mprintf("%Q", filepath);


### PR DESCRIPTION
on my system the program gets killed a few ms after rendering the main window, as reported in issue #395.

the attached patch fixes the problem.

FreeBSD sunspire 14.2-RELEASE FreeBSD 14.2-RELEASE releng/14.2-n269506-c8918d6c7412 GENERIC amd64