### PR TITLE
Fix unowned dir /usr/libexec/font-manager

### DIFF
--- a/fedora/font-manager.spec
+++ b/fedora/font-manager.spec
@@ -175,6 +175,7 @@ appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*.metain
 %{_datadir}/glib-2.0/schemas/%{DBusName}.gschema.xml
 
 %files -n font-viewer
+%dir %{_libexecdir}/%{name}
 %{_libexecdir}/%{name}/font-viewer
 %{_datadir}/metainfo/%{DBusName2}.metainfo.xml
 %{_datadir}/applications/%{DBusName2}.desktop


### PR DESCRIPTION
Either of these are correct, let me know if you prefer the latter

```
%dir %{_libexecdir}/%{name}
%{_libexecdir}/%{name}/font-viewer
```

or

```
%{_libexecdir}/%{name}/
```